### PR TITLE
fix: Add bootstrap SHA to release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,4 +1,5 @@
 {
+  "bootstrap-sha": "b489df4cf3eae08a25ed401db207a78100cf4fc9",
   "plugins": ["node-workspace"],
   "bump-minor-pre-major": true,
   "packages": {


### PR DESCRIPTION
I think release-please is confused because we didn't tell it what commit to start from. Hopefully this will do the trick.

fixes #8