### PR TITLE
build: avoid unnecessary steps in release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,16 +20,20 @@ jobs:
                   token: ${{secrets.GITHUB_TOKEN}}
 
             # Output which releases were created
-            - run: echo "A release was created."
-              if: ${{ steps.release.outputs.releases_created }}
+            - name: Output release info
+              run: |
+                echo "releases_created:" ${{ steps.release.outputs.releases_created }}
+                echo "packages/compat--release_created:" ${{ steps.release.outputs['packages/compat--release_created'] }}
+                echo "packages/object-schema--release_created:" ${{ steps.release.outputs['packages/object-schema--release_created'] }}
+                echo "packages/config-array--release_created" ${{ steps.release.outputs['packages/config-array--release_created'] }}
 
             # Check to see if we need to do any releases and if so check out the repo
             - uses: actions/checkout@v4
-              if: ${{ steps.release.outputs.releases_created }}
+              if: ${{ steps.release.outputs.releases_created == 'true' }}
 
             # Node.js release
             - uses: actions/setup-node@v4
-              if: ${{ steps.release.outputs.releases_created }}
+              if: ${{ steps.release.outputs.releases_created == 'true' }}
               with:
                   node-version: lts/*
                   registry-url: "https://registry.npmjs.org"
@@ -37,7 +41,7 @@ jobs:
             - run: |
                 npm install
                 npm run build
-              if: ${{ steps.release.outputs.releases_created }}
+              if: ${{ steps.release.outputs.releases_created == 'true' }}
 
             #-----------------------------------------------------------------------------
             # NOTE: Packages are released in order of dependency. The packages with the


### PR DESCRIPTION
Fixes https://github.com/eslint/rewrite/issues/8

In GitHub actions, steps' output properties always have _string_ values.

Per https://github.com/google-github-actions/release-please-action/issues/912 and https://github.com/google-github-actions/release-please-action/pull/915, a breaking change in `release-please-action@v4` is that when there are no releases created, instead of omitting `releases_created` property it sets it to a truthy string `"false"`.

This PR updates the condition `if: ${{ steps.release.outputs.releases_created }}` to `if: ${{ steps.release.outputs.releases_created == 'true' }}` to avoid running unnecessary steps when there are no releases created.