### PR TITLE
feat: sync packages meta

### DIFF
--- a/packages/compat/jsr.json
+++ b/packages/compat/jsr.json
@@ -3,8 +3,13 @@
   "version": "0.0.0",
   "exports":  "./dist/esm/index.js",
   "publish": {
-    "exclude": [
-        "!dist"
+    "include": [
+        "dist/esm/index.js",
+        "dist/esm/index.d.ts",
+        "dist/esm/types.d.ts",
+        "README.md",
+        "jsr.json",
+        "LICENSE"
     ]
   }
 }

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -14,9 +14,14 @@
     }
   },
   "files": [
-    "dist",
-    "LICENSE",
-    "README.md"
+    "dist/cjs/index.cjs",
+    "dist/cjs/index.d.cts",
+    "dist/cjs/types.d.ts",
+    "dist/esm/index.js",
+    "dist/esm/index.d.ts",
+    "dist/esm/types.d.ts",
+    "README.md",
+    "LICENSE"
   ],
   "publishConfig": {
     "access": "public"
@@ -26,7 +31,6 @@
   },
   "scripts": {
     "build": "rollup -c && tsc -p tsconfig.esm.json && tsc -p tsconfig.cjs.json",
-    "prepare": "npm run build",
     "test": "mocha tests/*.js"
   },
   "repository": {

--- a/packages/config-array/package.json
+++ b/packages/config-array/package.json
@@ -24,6 +24,9 @@
     "README.md",
     "LICENSE"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/eslint/rewrite.git"

--- a/packages/object-schema/jsr.json
+++ b/packages/object-schema/jsr.json
@@ -3,8 +3,13 @@
   "version": "2.0.3",
   "exports":  "./dist/esm/index.js",
   "publish": {
-    "exclude": [
-        "!dist"
+    "include": [
+        "dist/esm/index.js",
+        "dist/esm/index.d.ts",
+        "dist/esm/types.d.ts",
+        "README.md",
+        "jsr.json",
+        "LICENSE"
     ]
   }
 }

--- a/packages/object-schema/package.json
+++ b/packages/object-schema/package.json
@@ -14,16 +14,23 @@
     }
   },
   "files": [
-    "dist",
-    "LICENSE",
-    "README.md"
+    "dist/cjs/index.cjs",
+    "dist/cjs/index.d.cts",
+    "dist/cjs/types.d.ts",
+    "dist/esm/index.js",
+    "dist/esm/index.d.ts",
+    "dist/esm/types.d.ts",
+    "README.md",
+    "LICENSE"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "directories": {
     "test": "tests"
   },
   "scripts": {
     "build": "rollup -c && tsc -p tsconfig.esm.json && tsc -p tsconfig.cjs.json",
-    "prepare": "npm run build",
     "test": "mocha tests/"
   },
   "repository": {


### PR DESCRIPTION
Updates `package.json` in all three packages to align them with changes from the last few commits.

* Packages should have `"access": "public"`, which allows publishing a scoped package as public.
* `files` explicitly lists files that should be published from `dist/` to avoid publishing `types.ts`. (the same change is done in `jsr.json` files).
* Packages should not have a `prepare` script.

