### PR TITLE
docs: add `@eslint/compat` package to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ Monorepo for the rewrite of ESLint.
 
 This repository is the home of the following packages:
 
-* [`@eslint/object-schema`](tree/main/packages/object-schema)
-* [`@eslint/config-array`](tree/main/packages/config-array)
-* [`@eslint/compat`](tree/main/packages/compat)
+* [`@eslint/object-schema`](packages/object-schema)
+* [`@eslint/config-array`](packages/config-array)
+* [`@eslint/compat`](packages/compat)

--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ This repository is the home of the following packages:
 
 * [`@eslint/object-schema`](tree/main/packages/object-schema)
 * [`@eslint/config-array`](tree/main/packages/config-array)
+* [`@eslint/compat`](tree/main/packages/compat)


### PR DESCRIPTION
Adds `@eslint/compat` to the list of packages in README.