### PR TITLE
chore: do not publish ts files to npm

### DIFF
--- a/packages/compat/jsr.json
+++ b/packages/compat/jsr.json
@@ -4,10 +4,7 @@
     "exports": "./dist/esm/index.js",
     "publish": {
         "include": [
-            "dist/esm/index.js",
-            "dist/esm/index.d.ts",
-            "dist/esm/types.d.ts",
-            "dist/esm/types.ts",
+            "dist/esm/*",
             "README.md",
             "jsr.json",
             "LICENSE"

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -14,7 +14,7 @@
     }
   },
   "files": [
-    "dist"
+    "dist/**/*.{js,cjs,mjs,d.ts}"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/compat/src/fixup-rules.js
+++ b/packages/compat/src/fixup-rules.js
@@ -12,11 +12,11 @@
 // Types
 //-----------------------------------------------------------------------------
 
-/** @typedef {import("./types.ts").FixupRuleDefinition} FixupRuleDefinition */
-/** @typedef {import("./types.ts").FixupLegacyRuleDefinition} FixupLegacyRuleDefinition */
-/** @typedef {import("./types.ts").FixupPluginDefinition} FixupPluginDefinition */
-/** @typedef {import("./types.ts").FixupConfig} FixupConfig */
-/** @typedef {import("./types.ts").FixupConfigArray} FixupConfigArray */
+/** @typedef {import("./types.js").FixupRuleDefinition} FixupRuleDefinition */
+/** @typedef {import("./types.js").FixupLegacyRuleDefinition} FixupLegacyRuleDefinition */
+/** @typedef {import("./types.js").FixupPluginDefinition} FixupPluginDefinition */
+/** @typedef {import("./types.js").FixupConfig} FixupConfig */
+/** @typedef {import("./types.js").FixupConfigArray} FixupConfigArray */
 
 //-----------------------------------------------------------------------------
 // Data

--- a/packages/config-array/jsr.json
+++ b/packages/config-array/jsr.json
@@ -4,10 +4,7 @@
     "exports": "./dist/esm/index.js",
     "publish": {
         "include": [
-            "dist/esm/index.js",
-            "dist/esm/index.d.ts",
-            "dist/esm/types.ts",
-            "dist/esm/types.d.ts",
+            "dist/esm/*",
             "README.md",
             "jsr.json",
             "LICENSE"

--- a/packages/config-array/package.json
+++ b/packages/config-array/package.json
@@ -15,7 +15,7 @@
     }
   },
   "files": [
-    "dist"
+    "dist/**/*.{js,cjs,mjs,d.ts}"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/object-schema/jsr.json
+++ b/packages/object-schema/jsr.json
@@ -4,10 +4,7 @@
     "exports": "./dist/esm/index.js",
     "publish": {
         "include": [
-            "dist/esm/index.js",
-            "dist/esm/index.d.ts",
-            "dist/esm/types.ts",
-            "dist/esm/types.d.ts",
+            "dist/esm/*",
             "README.md",
             "jsr.json",
             "LICENSE"

--- a/packages/object-schema/package.json
+++ b/packages/object-schema/package.json
@@ -14,7 +14,7 @@
     }
   },
   "files": [
-    "dist"
+    "dist/**/*.{js,cjs,mjs,d.ts}"
   ],
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
this is to exclude ts files when publishing to npm.

npm:
```bash
npm pack -w packages/compat
npm notice 
npm notice 📦  @eslint/compat@1.0.1
npm notice === Tarball Contents === 
npm notice 11.4kB LICENSE            
npm notice 3.5kB  README.md          
npm notice 7.9kB  dist/cjs/index.cjs 
npm notice 776B   dist/cjs/types.d.ts
npm notice 1.6kB  dist/esm/index.d.ts
npm notice 7.8kB  dist/esm/index.js  
npm notice 776B   dist/esm/types.d.ts
npm notice 1.4kB  package.json       
npm notice === Tarball Details === 
npm notice name:          @eslint/compat                          
npm notice version:       1.0.1                                   
npm notice filename:      eslint-compat-1.0.1.tgz                 
npm notice package size:  8.2 kB                                  
npm notice unpacked size: 35.1 kB                                 
npm notice shasum:        71b147013f318a1e0e3daa664aed6f720700a9e3
npm notice integrity:     sha512-5eK8Rx8ZyPWpr[...]Rr192v0UilFXA==
npm notice total files:   8                                       
npm notice 
eslint-compat-1.0.1.tgz
```

refs: https://github.com/eslint/rewrite/pull/16#issuecomment-2104764938


jsr:
```bash
Checking for slow types in the public API...
Simulating publish of @eslint/compat@1.0.1 with files:
   file:///Users/weiran/repo/github/eslint-rewrite/packages/compat/LICENSE (11.09KB)
   file:///Users/weiran/repo/github/eslint-rewrite/packages/compat/README.md (3.41KB)
   file:///Users/weiran/repo/github/eslint-rewrite/packages/compat/dist/esm/index.d.ts (1.53KB)
   file:///Users/weiran/repo/github/eslint-rewrite/packages/compat/dist/esm/index.js (7.66KB)
   file:///Users/weiran/repo/github/eslint-rewrite/packages/compat/dist/esm/types.d.ts (776B)
   file:///Users/weiran/repo/github/eslint-rewrite/packages/compat/dist/esm/types.ts (982B)
   file:///Users/weiran/repo/github/eslint-rewrite/packages/compat/jsr.json (247B)
Warning Aborting due to --dry-run

Completed in 14s
```