### PR TITLE
fix: ConfigObject type

### DIFF
--- a/packages/config-array/src/config-array.js
+++ b/packages/config-array/src/config-array.js
@@ -21,7 +21,7 @@ import { filesAndIgnoresSchema } from "./files-and-ignores-schema.js";
 
 /** @typedef {import("@eslint/object-schema").PropertyDefinition} PropertyDefinition */
 /** @typedef {import("@eslint/object-schema").ObjectDefinition} ObjectDefinition */
-/** @typedef {import("./types.ts").BaseConfigObject} BaseConfigObject */
+/** @typedef {import("./types.ts").ConfigObject} ConfigObject */
 /** @typedef {import("minimatch").IMinimatchStatic} IMinimatchStatic */
 /** @typedef {import("minimatch").IMinimatch} IMinimatch */
 
@@ -125,7 +125,7 @@ class ConfigError extends Error {
 
 /**
  * Gets the name of a config object.
- * @param {BaseConfigObject} config The config object to get the name of.
+ * @param {ConfigObject} config The config object to get the name of.
  * @returns {string} The name of the config object.
  */
 function getConfigName(config) {

--- a/packages/config-array/src/types.ts
+++ b/packages/config-array/src/types.ts
@@ -3,7 +3,7 @@
  * @author Nicholas C. Zakas
  */
 
-export interface BaseConfigObject {
+export interface ConfigObject {
 	/**
 	 * The files to include.
 	 */
@@ -18,4 +18,7 @@ export interface BaseConfigObject {
 	 * The name of the config object.
 	 */
 	name?: string;
+
+	// may also have any number of other properties
+	[key: string]: unknown;
 }


### PR DESCRIPTION
This renames the `BaseConfigObject` interface to `ConfigObject` and allows for any number of other named properties. I think this better reflects the reality of the package.