### PR TITLE
fix: add code coverage npm scripts

### DIFF
--- a/.c8rc
+++ b/.c8rc
@@ -1,0 +1,5 @@
+{
+	"include": ["src/**/*.js"],
+	"reporter": ["lcov", "text-summary", "cobertura"],
+	"sourceMap": true
+}

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -26,7 +26,8 @@
     "build:cts": "node -e \"fs.copyFileSync('dist/esm/index.d.ts', 'dist/cjs/index.d.cts')\"",
     "build": "rollup -c && tsc -p tsconfig.esm.json && npm run build:cts",
     "test:jsr": "npx jsr@latest publish --dry-run",
-    "test": "mocha tests/*.js"
+    "test": "mocha tests/*.js",
+    "test:coverage": "c8 npm test"
   },
   "repository": {
     "type": "git",
@@ -46,6 +47,7 @@
   "homepage": "https://github.com/eslint/rewrite#readme",
   "devDependencies": {
     "@types/eslint": "^8.56.10",
+    "c8": "^9.1.0",
     "eslint": "^9.0.0",
     "mocha": "^10.4.0",
     "rollup": "^4.16.2",

--- a/packages/config-array/package.json
+++ b/packages/config-array/package.json
@@ -34,7 +34,8 @@
     "build": "rollup -c && npm run build:dedupe-types && tsc -p tsconfig.esm.json && npm run build:cts",
     "test:jsr": "npx jsr@latest publish --dry-run",
     "pretest": "npm run build",
-    "test": "mocha tests/"
+    "test": "mocha tests/",
+    "test:coverage": "c8 npm test"
   },
   "keywords": [
     "configuration",
@@ -49,6 +50,7 @@
   },
   "devDependencies": {
     "@types/minimatch": "^3.0.5",
+    "c8": "^9.1.0",
     "mocha": "^10.4.0",
     "rollup": "^4.16.2",
     "rollup-plugin-copy": "^3.5.0",

--- a/packages/object-schema/package.json
+++ b/packages/object-schema/package.json
@@ -26,7 +26,8 @@
     "build:cts": "node -e \"fs.copyFileSync('dist/esm/index.d.ts', 'dist/cjs/index.d.cts')\"",
     "build": "rollup -c && tsc -p tsconfig.esm.json && npm run build:cts",
     "test:jsr": "npx jsr@latest publish --dry-run",
-    "test": "mocha tests/"
+    "test": "mocha tests/",
+    "test:coverage": "c8 npm test"
   },
   "repository": {
     "type": "git",
@@ -45,10 +46,11 @@
   },
   "homepage": "https://github.com/eslint/rewrite#readme",
   "devDependencies": {
+    "c8": "^9.1.0",
     "mocha": "^10.4.0",
     "rollup": "^4.16.2",
-    "typescript": "^5.4.5",
-    "rollup-plugin-copy": "^3.5.0"
+    "rollup-plugin-copy": "^3.5.0",
+    "typescript": "^5.4.5"
   },
   "engines": {
     "node": "^18.18.0 || ^20.9.0 || >=21.1.0"


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Add npm scripts to collect code coverage from tests. Run with `npm run test:coverage` in a package directory.

#### What changes did you make? (Give an overview)

* Added a c8 config for the whole repo.
* Added c8 dependency and `test:coverage` script to each package.json file.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

This should trigger a new release.

<!-- markdownlint-disable-file MD004 -->
