### PR TITLE
fix: Wrap plugins that are wrapped in extends

### DIFF
--- a/packages/migrate-config/src/migrate-config.js
+++ b/packages/migrate-config/src/migrate-config.js
@@ -152,7 +152,7 @@ function convertESLintIgnoreToMinimatch(pattern) {
 }
 
 // cache for plugins needing compat
-const pluginsNeedingCompatCache = new Set();
+const pluginsNeedingCompatCache = new Set(pluginsNeedingCompat);
 
 /**
  * Determines if a plugin needs the compat utility.

--- a/packages/migrate-config/src/migrate-config.js
+++ b/packages/migrate-config/src/migrate-config.js
@@ -676,7 +676,7 @@ function migrateConfigObject(migration, config) {
 			 */
 			extendsArray.forEach(extend => {
 				if (extend.startsWith("plugin:")) {
-					const pluginName = extend.slice(7);
+					const pluginName = extend.slice(7, extend.indexOf("/"));
 					const normalizedPluginName = naming.normalizePackageName(
 						pluginName,
 						"eslint-plugin",

--- a/packages/migrate-config/src/migrate-config.js
+++ b/packages/migrate-config/src/migrate-config.js
@@ -164,22 +164,9 @@ function pluginNeedsCompat(pluginName) {
 		? pluginName.slice(0, pluginName.indexOf("/"))
 		: pluginName;
 
-	const normalizedName = naming.normalizePackageName(
-		pluginNameToTest,
-		"eslint-plugin",
+	return pluginsNeedingCompatCache.has(
+		naming.normalizePackageName(pluginNameToTest, "eslint-plugin"),
 	);
-
-	if (pluginsNeedingCompatCache.has(normalizedName)) {
-		return true;
-	}
-
-	const needsCompat = pluginsNeedingCompat.includes(normalizedName);
-
-	if (needsCompat) {
-		pluginsNeedingCompatCache.add(normalizedName);
-	}
-
-	return needsCompat;
 }
 
 /**

--- a/packages/migrate-config/tests/fixtures/basic-eslintrc/expected.cjs
+++ b/packages/migrate-config/tests/fixtures/basic-eslintrc/expected.cjs
@@ -1,15 +1,14 @@
+const {
+    fixupConfigRules,
+    fixupPluginRules,
+} = require("@eslint/compat");
+
 const prettier = require("eslint-plugin-prettier");
 const _import = require("eslint-plugin-import");
 const node = require("eslint-plugin-node");
 const promise = require("eslint-plugin-promise");
 const standard = require("eslint-plugin-standard");
 const typescriptEslint = require("@typescript-eslint/eslint-plugin");
-
-const {
-    fixupPluginRules,
-    fixupConfigRules,
-} = require("@eslint/compat");
-
 const globals = require("globals");
 const tsParser = require("@typescript-eslint/parser");
 const js = require("@eslint/js");

--- a/packages/migrate-config/tests/fixtures/basic-eslintrc/expected.mjs
+++ b/packages/migrate-config/tests/fixtures/basic-eslintrc/expected.mjs
@@ -1,10 +1,10 @@
+import { fixupConfigRules, fixupPluginRules } from "@eslint/compat";
 import prettier from "eslint-plugin-prettier";
 import _import from "eslint-plugin-import";
 import node from "eslint-plugin-node";
 import promise from "eslint-plugin-promise";
 import standard from "eslint-plugin-standard";
 import typescriptEslint from "@typescript-eslint/eslint-plugin";
-import { fixupPluginRules, fixupConfigRules } from "@eslint/compat";
 import globals from "globals";
 import tsParser from "@typescript-eslint/parser";
 import path from "node:path";

--- a/packages/migrate-config/tests/fixtures/no-globals-for-env/expected.cjs
+++ b/packages/migrate-config/tests/fixtures/no-globals-for-env/expected.cjs
@@ -1,15 +1,14 @@
+const {
+    fixupConfigRules,
+    fixupPluginRules,
+} = require("@eslint/compat");
+
 const prettier = require("eslint-plugin-prettier");
 const _import = require("eslint-plugin-import");
 const node = require("eslint-plugin-node");
 const promise = require("eslint-plugin-promise");
 const standard = require("eslint-plugin-standard");
 const typescriptEslint = require("@typescript-eslint/eslint-plugin");
-
-const {
-    fixupPluginRules,
-    fixupConfigRules,
-} = require("@eslint/compat");
-
 const tsParser = require("@typescript-eslint/parser");
 const js = require("@eslint/js");
 

--- a/packages/migrate-config/tests/fixtures/no-globals-for-env/expected.mjs
+++ b/packages/migrate-config/tests/fixtures/no-globals-for-env/expected.mjs
@@ -1,10 +1,10 @@
+import { fixupConfigRules, fixupPluginRules } from "@eslint/compat";
 import prettier from "eslint-plugin-prettier";
 import _import from "eslint-plugin-import";
 import node from "eslint-plugin-node";
 import promise from "eslint-plugin-promise";
 import standard from "eslint-plugin-standard";
 import typescriptEslint from "@typescript-eslint/eslint-plugin";
-import { fixupPluginRules, fixupConfigRules } from "@eslint/compat";
 import tsParser from "@typescript-eslint/parser";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/migrate-config/tests/fixtures/plugins-dedupe/.eslintrc.yml
+++ b/packages/migrate-config/tests/fixtures/plugins-dedupe/.eslintrc.yml
@@ -1,0 +1,5 @@
+root: true
+plugins:
+    - import
+extends:
+    - plugin:import/errors

--- a/packages/migrate-config/tests/fixtures/plugins-dedupe/.eslintrc.yml
+++ b/packages/migrate-config/tests/fixtures/plugins-dedupe/.eslintrc.yml
@@ -1,5 +1,7 @@
 root: true
 plugins:
     - import
+    - n
 extends:
     - plugin:import/errors
+    - plugin:n/recommended

--- a/packages/migrate-config/tests/fixtures/plugins-dedupe/expected.cjs
+++ b/packages/migrate-config/tests/fixtures/plugins-dedupe/expected.cjs
@@ -1,0 +1,23 @@
+const {
+    fixupConfigRules,
+    fixupPluginRules,
+} = require("@eslint/compat");
+
+const _import = require("eslint-plugin-import");
+const js = require("@eslint/js");
+
+const {
+    FlatCompat,
+} = require("@eslint/eslintrc");
+
+const compat = new FlatCompat({
+    baseDirectory: __dirname,
+    recommendedConfig: js.configs.recommended,
+    allConfig: js.configs.all
+});
+
+module.exports = [...fixupConfigRules(compat.extends("plugin:import/errors")), {
+    plugins: {
+        import: fixupPluginRules(_import),
+    },
+}];

--- a/packages/migrate-config/tests/fixtures/plugins-dedupe/expected.cjs
+++ b/packages/migrate-config/tests/fixtures/plugins-dedupe/expected.cjs
@@ -4,6 +4,7 @@ const {
 } = require("@eslint/compat");
 
 const _import = require("eslint-plugin-import");
+const n = require("eslint-plugin-n");
 const js = require("@eslint/js");
 
 const {
@@ -16,8 +17,12 @@ const compat = new FlatCompat({
     allConfig: js.configs.all
 });
 
-module.exports = [...fixupConfigRules(compat.extends("plugin:import/errors")), {
-    plugins: {
-        import: fixupPluginRules(_import),
+module.exports = [
+    ...fixupConfigRules(compat.extends("plugin:import/errors", "plugin:n/recommended")),
+    {
+        plugins: {
+            import: fixupPluginRules(_import),
+            n: fixupPluginRules(n),
+        },
     },
-}];
+];

--- a/packages/migrate-config/tests/fixtures/plugins-dedupe/expected.mjs
+++ b/packages/migrate-config/tests/fixtures/plugins-dedupe/expected.mjs
@@ -1,5 +1,6 @@
 import { fixupConfigRules, fixupPluginRules } from "@eslint/compat";
 import _import from "eslint-plugin-import";
+import n from "eslint-plugin-n";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import js from "@eslint/js";
@@ -14,8 +15,12 @@ const compat = new FlatCompat({
     allConfig: js.configs.all
 });
 
-export default [...fixupConfigRules(compat.extends("plugin:import/errors")), {
-    plugins: {
-        import: fixupPluginRules(_import),
+export default [
+    ...fixupConfigRules(compat.extends("plugin:import/errors", "plugin:n/recommended")),
+    {
+        plugins: {
+            import: fixupPluginRules(_import),
+            n: fixupPluginRules(n),
+        },
     },
-}];
+];

--- a/packages/migrate-config/tests/fixtures/plugins-dedupe/expected.mjs
+++ b/packages/migrate-config/tests/fixtures/plugins-dedupe/expected.mjs
@@ -1,0 +1,21 @@
+import { fixupConfigRules, fixupPluginRules } from "@eslint/compat";
+import _import from "eslint-plugin-import";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import js from "@eslint/js";
+import { FlatCompat } from "@eslint/eslintrc";
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+
+const compat = new FlatCompat({
+    baseDirectory: __dirname,
+    recommendedConfig: js.configs.recommended,
+    allConfig: js.configs.all
+});
+
+export default [...fixupConfigRules(compat.extends("plugin:import/errors")), {
+    plugins: {
+        import: fixupPluginRules(_import),
+    },
+}];

--- a/packages/migrate-config/tests/fixtures/release-it/expected.cjs
+++ b/packages/migrate-config/tests/fixtures/release-it/expected.cjs
@@ -1,11 +1,10 @@
-const prettier = require("eslint-plugin-prettier");
-const _import = require("eslint-plugin-import");
-
 const {
-    fixupPluginRules,
     fixupConfigRules,
+    fixupPluginRules,
 } = require("@eslint/compat");
 
+const prettier = require("eslint-plugin-prettier");
+const _import = require("eslint-plugin-import");
 const globals = require("globals");
 const js = require("@eslint/js");
 

--- a/packages/migrate-config/tests/fixtures/release-it/expected.mjs
+++ b/packages/migrate-config/tests/fixtures/release-it/expected.mjs
@@ -1,6 +1,6 @@
+import { fixupConfigRules, fixupPluginRules } from "@eslint/compat";
 import prettier from "eslint-plugin-prettier";
 import _import from "eslint-plugin-import";
-import { fixupPluginRules, fixupConfigRules } from "@eslint/compat";
 import globals from "globals";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/migrate-config/tests/migrate-config-cli.test.js
+++ b/packages/migrate-config/tests/migrate-config-cli.test.js
@@ -21,6 +21,8 @@ const filePaths = [
 	"reveal-md/.eslintrc",
 	"release-it/.eslintrc.json",
 	"no-globals-for-env/.eslintrc.yml",
+	"overrides-extends/.eslintrc.json",
+	"plugins-dedupe/.eslintrc.yml",
 ].map(file => `tests/fixtures/${file}`);
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Fixes a bug where the same plugin referenced in `extends` and `plugins` may result in a "Cannot redefine plugin" error.

#### What changes did you make? (Give an overview)

- Check `extends` before `plugins` to determine if a plugin needs to be wrapped by the compat utility.
- Added tests

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
