### PR TITLE
chore: remove unused rollup dev dependencies

### DIFF
--- a/packages/migrate-config/package.json
+++ b/packages/migrate-config/package.json
@@ -40,8 +40,6 @@
     "@types/eslint": "^8.56.10",
     "eslint": "^9.0.0",
     "mocha": "^10.4.0",
-    "rollup": "^4.16.2",
-    "rollup-plugin-copy": "^3.5.0",
     "typescript": "^5.4.5"
   },
   "engines": {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

`migrate-config` doesn't use rollup. This removes unused rollup and rollup-related dev dependencies. 

#### What changes did you make? (Give an overview)

Removed `rollup` and `rollup-plugin-copy` from `packages/migrate-config/package.json`.

#### Related Issues

No.

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
