### PR TITLE
ci: build packages in Verify Files job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,9 @@ jobs:
                   node-version: "lts/*"
 
             - name: Install Packages
-              run: npm install
+              run: |
+                  npm install
+                  npm run build
 
             - name: Lint Files
               run: npm run lint


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Fixes Verify Files job.

In two recent PRs (https://github.com/eslint/rewrite/pull/38 & https://github.com/eslint/rewrite/pull/39), running eslint fails with:

```
Oops! Something went wrong! :(

ESLint: 9.4.0

Error: Cannot find module '/home/runner/work/rewrite/rewrite/node_modules/@eslint/config-array/dist/cjs/index.cjs'
```

I believe what happens is the following:

1. We recently released eslint v9.4.0, which is the first version that uses `@eslint/config-array`.
2. `npm install` here now installs eslint v9.4.0.
3. Since `@eslint/config-array` is in this monorepo, and the version satisfies semver range declared in `eslint`, `npm install` doesn't install `@eslint/config-array` from npm in `node_modules/eslint/node_modules`, but lets `eslint` use top level `node_modules/@eslint/config-array`. However, this is a symlink to `packages/config-array`, which therefore must be built before running eslint.

#### What changes did you make? (Give an overview)

Added `npm run build` in the Verify Files job.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
