### PR TITLE
chore: don't generate `package-lock.json`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock = false


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Prevents generating `package-lock.json` files.

#### What changes did you make? (Give an overview)

Added a `.npmrc` file with `package-lock = false`, like in other projects.

#### Related Issues

No, but when trying to locally reproduce CI failures that https://github.com/eslint/rewrite/pull/40 will fix, I couldn't reproduce it until I realized that I had a `package-lock.json` file with eslint v9.3.0 from previous installs, so it seems better not to have this file.

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
