### PR TITLE
fix: Add 'main' and 'types' entries to package.json

### DIFF
--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -3,6 +3,8 @@
   "version": "1.0.3",
   "description": "Compatibility utilities for ESLint",
   "type": "module",
+  "main": "dist/esm/index.js",
+  "types": "dist/esm/index.d.ts",
   "exports": {
     "require": {
       "types": "./dist/cjs/index.d.cts",

--- a/packages/config-array/package.json
+++ b/packages/config-array/package.json
@@ -4,6 +4,8 @@
   "description": "General purpose glob-based configuration matching.",
   "author": "Nicholas C. Zakas",
   "type": "module",
+  "main": "dist/esm/index.js",
+  "types": "dist/esm/index.d.ts",
   "exports": {
     "require": {
       "types": "./dist/cjs/index.d.cts",

--- a/packages/object-schema/package.json
+++ b/packages/object-schema/package.json
@@ -3,6 +3,8 @@
   "version": "2.1.3",
   "description": "An object schema merger/validator",
   "type": "module",
+  "main": "dist/esm/index.js",
+  "types": "dist/esm/index.d.ts",
   "exports": {
     "require": {
       "types": "./dist/cjs/index.d.cts",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Add `main` and `types` entries to `package.json` files. Even though we have `exports` specified, some tools still rely on these old, top-level entries.

#### What changes did you make? (Give an overview)

- Added `main` and `types` entries to `package.json` files in `compat`, `config-array`, and `object-schema`.

#### Related Issues

fixes #46

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
