### PR TITLE
fix!: treat `*` as a universal pattern

### DIFF
--- a/packages/config-array/README.md
+++ b/packages/config-array/README.md
@@ -286,7 +286,7 @@ A few things to keep in mind:
 -   You must pass in the absolute filename to get a config for.
 -   The returned config object never has `files`, `ignores`, or `name` properties; the only properties on the object will be the other configuration options specified.
 -   The config array caches configs, so subsequent calls to `getConfig()` with the same filename will return in a fast lookup rather than another calculation.
--   A config will only be generated if the filename matches an entry in a `files` key. A config will not be generated without matching a `files` key (configs without a `files` key are only applied when another config with a `files` key is applied; configs without `files` are never applied on their own). Any config with a `files` key entry ending with `/**` or `/*` will only be applied if another entry in the same `files` key matches or another config matches.
+-   A config will only be generated if the filename matches an entry in a `files` key. A config will not be generated without matching a `files` key (configs without a `files` key are only applied when another config with a `files` key is applied; configs without `files` are never applied on their own). Any config with a `files` key entry that is `*` or ends with `/**` or `/*` will only be applied if another entry in the same `files` key matches or another config matches.
 
 ## Determining Ignored Paths
 

--- a/packages/config-array/src/config-array.js
+++ b/packages/config-array/src/config-array.js
@@ -884,7 +884,7 @@ export class ConfigArray extends Array {
 
 		const matchingConfigIndices = [];
 		let matchFound = false;
-		const universalPattern = /\/\*{1,2}$/u;
+		const universalPattern = /^\*$|\/\*{1,2}$/u;
 
 		this.forEach((config, index) => {
 			if (!config.files) {
@@ -909,8 +909,8 @@ export class ConfigArray extends Array {
 			}
 
 			/*
-			 * If a config has a files pattern ending in /** or /*, and the
-			 * filePath only matches those patterns, then the config is only
+			 * If a config has a files pattern * or patterns ending in /** or /*,
+			 * and the filePath only matches those patterns, then the config is only
 			 * applied if there is another config where the filePath matches
 			 * a file with a specific extensions such as *.js.
 			 */

--- a/packages/config-array/tests/config-array.test.js
+++ b/packages/config-array/tests/config-array.test.js
@@ -1434,6 +1434,26 @@ describe("ConfigArray", () => {
 				);
 			});
 
+			it('should return "unconfigured" when there is only * pattern', () => {
+				configs = new ConfigArray(
+					[
+						{
+							files: ["*"],
+						},
+					],
+					{
+						basePath,
+					},
+				);
+
+				configs.normalizeSync();
+
+				assert.strictEqual(
+					configs.getConfigStatus(path.join(basePath, "a.js")),
+					"unconfigured",
+				);
+			});
+
 			it('should return "matched" when files pattern matches and there is a pattern ending with /**', () => {
 				configs = new ConfigArray(
 					[


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Fixes the bug reported in https://github.com/eslint/eslint/issues/18550.

#### What changes did you make? (Give an overview)

Changed `getConfigWithStatus` to treat lone `*` as a universal pattern.

This means that files matching only `*` will be "unconfigured".

#### Related Issues

https://github.com/eslint/eslint/issues/18550

#### Is there anything you'd like reviewers to focus on?

I tagged this as `fix!` because I think this should be treated as a breaking change for the config-array package.

<!-- markdownlint-disable-file MD004 -->
