### PR TITLE
fix!: Allow escaping characters on Windows

### DIFF
--- a/packages/config-array/package.json
+++ b/packages/config-array/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@eslint/object-schema": "^2.1.4",
     "debug": "^4.3.1",
-    "minimatch": "^3.0.5"
+    "minimatch": "^3.1.2"
   },
   "devDependencies": {
     "@types/minimatch": "^3.0.5",

--- a/packages/config-array/src/config-array.js
+++ b/packages/config-array/src/config-array.js
@@ -60,6 +60,7 @@ const negatedMinimatchCache = new Map();
 const MINIMATCH_OPTIONS = {
 	// matchBase: true,
 	dot: true,
+	allowWindowsEscape: true,
 };
 
 /**

--- a/packages/config-array/tests/config-array.test.js
+++ b/packages/config-array/tests/config-array.test.js
@@ -970,6 +970,107 @@ describe("ConfigArray", () => {
 				assert.strictEqual(config, undefined);
 			});
 
+			// https://github.com/eslint/eslint/issues/18597
+			it("should correctly handle escaped characters in `files` patterns", () => {
+				configs = new ConfigArray(
+					[
+						{
+							files: ["src/\\{a,b}.js"],
+							defs: {
+								severity: "error",
+							},
+						},
+					],
+					{ basePath, schema },
+				);
+
+				configs.normalizeSync();
+
+				assert.strictEqual(
+					configs.getConfig(path.resolve(basePath, "src", "a.js")),
+					undefined,
+				);
+				assert.strictEqual(
+					configs.getConfig(path.resolve(basePath, "src", "b.js")),
+					undefined,
+				);
+				assert.strictEqual(
+					configs.getConfig(path.resolve(basePath, "src", "{a,b}.js"))
+						.defs.severity,
+					"error",
+				);
+			});
+
+			it("should correctly handle escaped characters in `ignores` patterns", () => {
+				configs = new ConfigArray(
+					[
+						{
+							files: ["**/*.js"],
+							ignores: ["src/\\{a,b}.js"],
+							defs: {
+								severity: "error",
+							},
+						},
+					],
+					{ basePath, schema },
+				);
+
+				configs.normalizeSync();
+
+				assert.strictEqual(
+					configs.getConfig(path.resolve(basePath, "src", "a.js"))
+						.defs.severity,
+					"error",
+				);
+				assert.strictEqual(
+					configs.getConfig(path.resolve(basePath, "src", "b.js"))
+						.defs.severity,
+					"error",
+				);
+				assert.strictEqual(
+					configs.getConfig(
+						path.resolve(basePath, "src", "{a,b}.js"),
+					),
+					undefined,
+				);
+			});
+
+			it("should correctly handle escaped characters in global `ignores` patterns", () => {
+				configs = new ConfigArray(
+					[
+						{
+							files: ["**/*.js"],
+							defs: {
+								severity: "error",
+							},
+						},
+						{
+							ignores: ["src/\\{a,b}.js"],
+						},
+					],
+					{ basePath, schema },
+				);
+
+				configs.normalizeSync();
+
+				assert.strictEqual(
+					configs.getConfig(path.resolve(basePath, "src", "a.js"))
+						.defs.severity,
+					"error",
+				);
+				assert.strictEqual(
+					configs.getConfig(path.resolve(basePath, "src", "b.js"))
+						.defs.severity,
+					"error",
+				);
+				assert.strictEqual(
+					configs.getConfig(
+						path.resolve(basePath, "src", "{a,b}.js"),
+					),
+					undefined,
+				);
+			});
+
 			// https://github.com/eslint/eslint/issues/17103
 			describe("ignores patterns should be properly applied", () => {
 				it("should return undefined when a filename matches an ignores pattern but not a files pattern", () => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Allows using `\` as an escape character in patterns regardless of the operating system. In particular, on Windows.

#### What changes did you make? (Give an overview)

Enabled [`allowWindowsEscape`](https://github.com/isaacs/minimatch/tree/v3.1.2?tab=readme-ov-file#allowwindowsescape) minimatch option.

#### Related Issues

refs https://github.com/eslint/eslint/issues/18597

#### Is there anything you'd like reviewers to focus on?

Should this maybe be marked as a breaking change for this package?

<!-- markdownlint-disable-file MD004 -->
