### PR TITLE
fix: skip add plugin when already imported

### DIFF
--- a/packages/migrate-config/src/migrate-config.js
+++ b/packages/migrate-config/src/migrate-config.js
@@ -607,7 +607,11 @@ function createPlugins(plugins, migration) {
 				bindings: ["fixupPluginRules"],
 				added: true,
 			});
-		} else {
+		} else if (
+			!migration.imports
+				.get("@eslint/compat")
+				.bindings.includes("fixupPluginRules")
+		) {
 			migration.imports
 				.get("@eslint/compat")
 				.bindings.push("fixupPluginRules");

--- a/packages/migrate-config/tests/fixtures/import-duplicate/.eslintrc.cjs
+++ b/packages/migrate-config/tests/fixtures/import-duplicate/.eslintrc.cjs
@@ -1,0 +1,8 @@
+module.exports = {
+  plugins: ["react"],
+  overrides: [
+    {
+      plugins: ["react-hooks"],
+    }
+  ]
+};

--- a/packages/migrate-config/tests/fixtures/import-duplicate/expected.cjs
+++ b/packages/migrate-config/tests/fixtures/import-duplicate/expected.cjs
@@ -1,0 +1,17 @@
+const react = require("eslint-plugin-react");
+
+const {
+    fixupPluginRules,
+} = require("@eslint/compat");
+
+const reactHooks = require("eslint-plugin-react-hooks");
+
+module.exports = [{
+    plugins: {
+        react: fixupPluginRules(react),
+    },
+}, {
+    plugins: {
+        "react-hooks": fixupPluginRules(reactHooks),
+    },
+}];

--- a/packages/migrate-config/tests/fixtures/import-duplicate/expected.mjs
+++ b/packages/migrate-config/tests/fixtures/import-duplicate/expected.mjs
@@ -1,0 +1,13 @@
+import react from "eslint-plugin-react";
+import { fixupPluginRules } from "@eslint/compat";
+import reactHooks from "eslint-plugin-react-hooks";
+
+export default [{
+    plugins: {
+        react: fixupPluginRules(react),
+    },
+}, {
+    plugins: {
+        "react-hooks": fixupPluginRules(reactHooks),
+    },
+}];

--- a/packages/migrate-config/tests/migrate-config-cli.test.js
+++ b/packages/migrate-config/tests/migrate-config-cli.test.js
@@ -25,6 +25,7 @@ const filePaths = [
 	"plugins-dedupe/.eslintrc.yml",
 	"gitignore-simple/.eslintrc.json",
 	"gitignore-complex/.eslintrc.json",
+	"import-duplicate/.eslintrc.cjs",
 ].map(file => `tests/fixtures/${file}`);
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?
prevent syntax error which threw by duplicate import fixupPluginRules because of multiple compat needs plugins.

#### What changes did you make? (Give an overview)
- skip add fixupPluginRules when already pushed in bindings

#### Related Issues
fixes #72

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
