### PR TITLE
fix: Escape `{` and `(` characters in `convertIgnorePatternToMinimatch`

### DIFF
--- a/packages/compat/tests/ignore-file.js
+++ b/packages/compat/tests/ignore-file.js
@@ -32,6 +32,19 @@ describe("@eslint/compat", () => {
 			["!src/**", "!src/**/*"],
 			["*/foo.js", "*/foo.js"],
 			["*/foo.js/", "*/foo.js/"],
+			["src/{a,b}.js", "src/\\{a,b}.js"],
+			["src/?(a)b.js", "src/?\\(a)b.js"],
+			["{.js", "**/\\{.js"],
+			["(.js", "**/\\(.js"],
+			["(.js", "**/\\(.js"],
+			["{(.js", "**/\\{\\(.js"],
+			["{bar}/{baz}", "\\{bar}/\\{baz}"],
+			["\\[foo]/{bar}/{baz}", "\\[foo]/\\{bar}/\\{baz}"],
+			["src/\\{a}", "src/\\{a}"],
+			["src/\\(a)", "src/\\(a)"],
+			["src/\\{a}/{b}", "src/\\{a}/\\{b}"],
+			["src/\\(a)/(b)", "src/\\(a)/\\(b)"],
+			["a\\bc{de(f\\gh\\{i\\(j{(", "**/a\\bc\\{de\\(f\\gh\\{i\\(j\\{\\("],
 		];
 
 		tests.forEach(([pattern, expected]) => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Improves correctness of `convertIgnorePatternToMinimatch()` by escaping `{` and `(` characters, which are just literal characters in gitignore patterns but can form brace expansion or extglob syntax in minimatch patterns.

For example, gitignore pattern `src/{a,b}.js` ignores file `src/{a,b}.js`. But, the same minimatch pattern `src/{a,b}.js` ignores files `src/a.js` and `src/b.js`. By escaping `{`, we get a minimatch pattern `src/\{a,b}.js` that matches the same as gitignore pattern `src/{a,b}.js`.

#### What changes did you make? (Give an overview)

Updated `convertIgnorePatternToMinimatch()` to escape `{` and `(` characters.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
