### PR TITLE
fix: Update outdated dependency (minimatch)

### DIFF
--- a/packages/config-array/package.json
+++ b/packages/config-array/package.json
@@ -48,10 +48,9 @@
   "dependencies": {
     "@eslint/object-schema": "^2.1.4",
     "debug": "^4.3.1",
-    "minimatch": "^3.1.2"
+    "minimatch": "^9.0.5"
   },
   "devDependencies": {
-    "@types/minimatch": "^3.0.5",
     "c8": "^9.1.0",
     "mocha": "^10.4.0",
     "rollup": "^4.16.2",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

I noticed that minimatch was set to a version released 2 years ago. The latest version has a broader node compat than eslint so that doesn't seem to be the reason

#### What changes did you make? (Give an overview)

```diff
- "minimatch": "^3.1.2"
+ "minimatch": "^9.0.5"
```