### PR TITLE
build: switch to `googleapis/release-please-action`

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,7 @@ jobs:
     release-please:
         runs-on: ubuntu-latest
         steps:
-            - uses: GoogleCloudPlatform/release-please-action@v4
+            - uses: googleapis/release-please-action@v4
               id: release
               with:
                   token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Switches to the officially supported Release Please Action, which is [`googleapis/release-please-action`](https://github.com/googleapis/release-please-action). 

#### What changes did you make? (Give an overview)

Updated `.github/workflows/release-please.yml` to use `googleapis/release-please-action@v4` instead of `GoogleCloudPlatform/release-please-action@v4`.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
