### PR TITLE
feat!: Add getLoc/getRange to SourceCode interface

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -31,13 +31,31 @@ export interface FileProblem {
 //------------------------------------------------------------------------------
 
 /**
- * Represents an AST node or token with location information.
+ * Represents an AST node or token with location information in ESLint format.
  */
-export interface SyntaxElement {
+export interface ESLintSyntaxElement {
 	loc: SourceLocation;
-	range: [number, number];
-	[key: string]: any;
+	range: SourceRange;
 }
+
+/**
+ * Represents an AST node or token with location information in unist format.
+ */
+export interface UnistSyntaxElement {
+	position: SourceLocation;
+}
+
+/**
+ * Represents an AST node or token with location information in postcss format.
+ */
+export interface PostCSSSyntaxElement {
+	source: SourceLocation;
+}
+
+export type SyntaxElement =
+	| ESLintSyntaxElement
+	| UnistSyntaxElement
+	| PostCSSSyntaxElement;
 
 /**
  * Represents the start and end coordinates of a node inside the source.
@@ -48,12 +66,19 @@ export interface SourceLocation {
 }
 
 /**
- * Represents a location coordinate inside the source.
+ * Represents a location coordinate inside the source. ESLint-style formats
+ * have just `line` and `column` while others may have `offset` as well.
  */
 export interface Position {
 	line: number;
 	column: number;
+	offset?: number;
 }
+
+/**
+ * Represents a range of characters in the source.
+ */
+export type SourceRange = [number, number];
 
 //------------------------------------------------------------------------------
 // Config
@@ -299,6 +324,16 @@ interface SourceCodeBase {
 	 * just this source code object.
 	 */
 	visitorKeys?: Record<string, Array<string>>;
+
+	/**
+	 * Retrieves the equivalent of `loc` for a given node or token.
+	 */
+	getLoc(nodeOrToken: SyntaxElement): SourceLocation;
+
+	/**
+	 * Retrieves the equivalent of `range` for a given node or token.
+	 */
+	getRange(nodeOrToken: SyntaxElement): SourceRange;
 
 	/**
 	 * Traversal of AST.


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Updates the `SourceCode` interface with `getLoc()` and `getRange()` methods.

#### What changes did you make? (Give an overview)

- Added `getLoc()` method to `SourceCode` interface
- Added `getRange()` method to `SourceCode` interface
- Added `SourceRange` interface
- Updated `SyntaxElement` type to be a union of several popular AST-location formats
- Added an optional `offset` property to `Position`, as many ASTs support that

#### Related Issues

Refs https://github.com/eslint/eslint/issues/18695

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

I marked this as breaking as existing implementations of `SourceCode` would now be invalid.

Also, I thought that including different formats of `SyntaxElement` would provide the best developer experience. Otherwise, I'd need to set `SourceCode.ast` to `Object`, so there would effectively be no type checking or intellisense available. I'm not sure if that makes the most sense.

<!-- markdownlint-disable-file MD004 -->
