### PR TITLE
chore: setup typescript-eslint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -56,16 +56,8 @@ export default [
 	},
 
 	// Typescript
-	// {
-	// 	files: ["**/*.ts"],
-	// 	...tseslint.configs.recommended[0],
-	// 	rules: {
-	// 		...tseslint.configs.recommended[1].rules,
-	// 		...tseslint.configs.recommended[2].rules,
-	// 	},
-	// },
 	...tseslint.config({
 		files: ["**/*.ts"],
-		extends: tseslint.configs.recommended,
+		extends: [...tseslint.configs.strict, ...tseslint.configs.stylistic],
 	}),
 ];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -55,9 +55,12 @@ export default [
 		},
 	},
 
-	// Typescript
+	// TypeScript
 	...tseslint.config({
 		files: ["**/*.ts"],
 		extends: [...tseslint.configs.strict, ...tseslint.configs.stylistic],
+		rules: {
+			"no-use-before-define": "off",
+		},
 	}),
 ];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,5 @@
 import eslintConfigESLint from "eslint-config-eslint";
+import tseslint from "typescript-eslint";
 
 const eslintPluginJSDoc = eslintConfigESLint.find(
 	config => config.plugins?.jsdoc,
@@ -51,6 +52,16 @@ export default [
 				before: "readonly",
 				after: "readonly",
 			},
+		},
+	},
+
+	// Typescript
+	{
+		files: ["**/*.ts"],
+		...tseslint.configs.recommended[0],
+		rules: {
+			...tseslint.configs.recommended[1].rules,
+			...tseslint.configs.recommended[2].rules,
 		},
 	},
 ];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -56,12 +56,16 @@ export default [
 	},
 
 	// Typescript
-	{
+	// {
+	// 	files: ["**/*.ts"],
+	// 	...tseslint.configs.recommended[0],
+	// 	rules: {
+	// 		...tseslint.configs.recommended[1].rules,
+	// 		...tseslint.configs.recommended[2].rules,
+	// 	},
+	// },
+	...tseslint.config({
 		files: ["**/*.ts"],
-		...tseslint.configs.recommended[0],
-		rules: {
-			...tseslint.configs.recommended[1].rules,
-			...tseslint.configs.recommended[2].rules,
-		},
-	},
+		extends: tseslint.configs.recommended,
+	}),
 ];

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "lint-staged": "^15.2.0",
     "prettier": "^3.1.1",
     "typescript": "^5.5.3",
-    "typescript-eslint": "^8.0.0-alpha.45",
+    "typescript-eslint": "^8.0.0",
     "yorkie": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "got": "^14.4.1",
     "lint-staged": "^15.2.0",
     "prettier": "^3.1.1",
+    "typescript": "^5.5.3",
+    "typescript-eslint": "^8.0.0-alpha.45",
     "yorkie": "^2.0.0"
   }
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -127,9 +127,7 @@ export type RuleConfig = Severity | [Severity, ...unknown[]];
 /**
  * A collection of rules and their configurations.
  */
-export interface RulesConfig {
-	[ruleId: string]: RuleConfig;
-}
+export type RulesConfig = Record<string, RuleConfig>;
 
 //------------------------------------------------------------------------------
 // Languages
@@ -215,7 +213,7 @@ export interface NotOkParseResult {
 	/**
 	 * Any parsing errors, whether fatal or not. (only when ok: false)
 	 */
-	errors: Array<FileError>;
+	errors: FileError[];
 
 	/**
 	 * Any additional data that the parser wants to provide.
@@ -252,7 +250,7 @@ export interface VisitTraversalStep {
 	kind: 1;
 	target: object;
 	phase: 1 /* enter */ | 2 /* exit */;
-	args: Array<unknown>;
+	args: unknown[];
 }
 
 /**
@@ -262,7 +260,7 @@ export interface CallTraversalStep {
 	kind: 2;
 	target: string;
 	phase?: string;
-	args: Array<unknown>;
+	args: unknown[];
 }
 
 export type TraversalStep = VisitTraversalStep | CallTraversalStep;
@@ -306,7 +304,7 @@ interface SourceCodeBase {
 	 * When present, this overrides the `visitorKeys` on the language for
 	 * just this source code object.
 	 */
-	visitorKeys?: Record<string, Array<string>>;
+	visitorKeys?: Record<string, string[]>;
 
 	/**
 	 * Retrieves the equivalent of `loc` for a given node or token.
@@ -333,23 +331,23 @@ interface SourceCodeBase {
 	 * along with any problems found in evaluating the directives.
 	 */
 	getDisableDirectives?(): {
-		directives: Array<Directive>;
-		problems: Array<FileProblem>;
+		directives: Directive[];
+		problems: FileProblem[];
 	};
 
 	/**
 	 * Returns an array of all inline configuration nodes found in the
 	 * source code.
 	 */
-	getInlineConfigNodes?(): Array<object>;
+	getInlineConfigNodes?(): object[];
 
 	/**
 	 * Applies configuration found inside of the source code. This method is only
 	 * called when ESLint is running with inline configuration allowed.
 	 */
 	applyInlineConfig?(): {
-		configs: Array<InlineConfigElement>;
-		problems: Array<FileProblem>;
+		configs: InlineConfigElement[];
+		problems: FileProblem[];
 	};
 
 	/**
@@ -410,7 +408,7 @@ export interface Language {
 	/**
 	 * The traversal path that tools should take when evaluating the AST
 	 */
-	visitorKeys?: Record<string, Array<string>>;
+	visitorKeys?: Record<string, string[]>;
 
 	/**
 	 * Validates languageOptions for this language.
@@ -426,7 +424,7 @@ export interface Language {
 	matchesSelectorClass?(
 		className: string,
 		node: object,
-		ancestry: Array<object>,
+		ancestry: object[],
 	): boolean;
 
 	/**

--- a/packages/object-schema/src/types.ts
+++ b/packages/object-schema/src/types.ts
@@ -36,16 +36,19 @@ export interface PropertyDefinition {
 	/**
 	 * The strategy to merge the property.
 	 */
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- This is a generic type
 	merge: BuiltInMergeStrategy | ((target: any, source: any) => any);
 
 	/**
 	 * The strategy to validate the property.
 	 */
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- This is a generic type
 	validate: BuiltInValidationStrategy | ((value: any) => void);
 
 	/**
 	 * The schema for the object value of this property.
 	 */
+	// eslint-disable-next-line no-use-before-define -- Ignore for recursive type
 	schema?: ObjectDefinition;
 }
 

--- a/packages/object-schema/src/types.ts
+++ b/packages/object-schema/src/types.ts
@@ -36,19 +36,18 @@ export interface PropertyDefinition {
 	/**
 	 * The strategy to merge the property.
 	 */
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- This is a generic type
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/eslint/rewrite/pull/90#discussion_r1687206213
 	merge: BuiltInMergeStrategy | ((target: any, source: any) => any);
 
 	/**
 	 * The strategy to validate the property.
 	 */
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- This is a generic type
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- https://github.com/eslint/rewrite/pull/90#discussion_r1687206213
 	validate: BuiltInValidationStrategy | ((value: any) => void);
 
 	/**
 	 * The schema for the object value of this property.
 	 */
-	// eslint-disable-next-line no-use-before-define -- Ignore for recursive type
 	schema?: ObjectDefinition;
 }
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Enable linting for typescript files.

#### What changes did you make? (Give an overview)

- Enable typescript-eslint for all ts files.
- Fixed lint errors for `no-use-before-define` rule.
- Disabled `@typescript-eslint/no-explicit-any` for some generic types.

#### Related Issues

Fix https://github.com/eslint/rewrite/issues/69

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
Currently `8.0.0-alpha.45` supports ESLint v9, we will need to update it later once a stable version is released.
<!-- markdownlint-disable-file MD004 -->
