### PR TITLE
feat: `eslint-plugin-react` supports ESLint v9

### DIFF
--- a/packages/migrate-config/src/compat-plugins.js
+++ b/packages/migrate-config/src/compat-plugins.js
@@ -6,6 +6,5 @@
 export default [
 	"eslint-plugin-ava",
 	"eslint-plugin-react-hooks",
-	"eslint-plugin-react",
 	"eslint-plugin-import",
 ];

--- a/packages/migrate-config/tests/fixtures/import-duplicate/.eslintrc.cjs
+++ b/packages/migrate-config/tests/fixtures/import-duplicate/.eslintrc.cjs
@@ -1,5 +1,5 @@
 module.exports = {
-  plugins: ["react"],
+  plugins: ["import"],
   overrides: [
     {
       plugins: ["react-hooks"],

--- a/packages/migrate-config/tests/fixtures/import-duplicate/expected.cjs
+++ b/packages/migrate-config/tests/fixtures/import-duplicate/expected.cjs
@@ -1,4 +1,4 @@
-const react = require("eslint-plugin-react");
+const _import = require("eslint-plugin-import");
 
 const {
     fixupPluginRules,
@@ -8,7 +8,7 @@ const reactHooks = require("eslint-plugin-react-hooks");
 
 module.exports = [{
     plugins: {
-        react: fixupPluginRules(react),
+        import: fixupPluginRules(_import),
     },
 }, {
     plugins: {

--- a/packages/migrate-config/tests/fixtures/import-duplicate/expected.mjs
+++ b/packages/migrate-config/tests/fixtures/import-duplicate/expected.mjs
@@ -1,10 +1,10 @@
-import react from "eslint-plugin-react";
+import _import from "eslint-plugin-import";
 import { fixupPluginRules } from "@eslint/compat";
 import reactHooks from "eslint-plugin-react-hooks";
 
 export default [{
     plugins: {
-        react: fixupPluginRules(react),
+        import: fixupPluginRules(_import),
     },
 }, {
     plugins: {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

`eslint-plugin-react` now supports ESLint v9. This PR updates `@eslint/migrate-config` to not use the compat utility with `eslint-plugin-react` in generated configs.

#### What changes did you make? (Give an overview)

Removed `eslint-plugin-react` from the list of plugins that need the compat utility.

Also replaced `eslint-plugin-react` with `eslint-plugin-import` in tests that checks how migration works with two plugins that need the compat utility.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
