### PR TITLE
fix: `basePath` directory can never be ignored

### DIFF
--- a/packages/config-array/src/config-array.js
+++ b/packages/config-array/src/config-array.js
@@ -1024,6 +1024,11 @@ export class ConfigArray extends Array {
 			.relative(this.basePath, directoryPath)
 			.replace(/\\/gu, "/");
 
+		// basePath directory can never be ignored
+		if (relativeDirectoryPath === "") {
+			return false;
+		}
+
 		if (relativeDirectoryPath.startsWith("..")) {
 			return true;
 		}


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Fixes a bug in `ConfigArray#isDirectoryIgnored()`.

When `basePath` directory is passed in as the `directoryPath` to check, `isDirectoryIgnored()` mistakenly checks `/` against ignore patterns. Then it can match, and thus return `true`, patterns like `/` (which should be no-op/invalid as an absolute path pattern) or `**` (which is valid but should not match the `basePath` directory). 

#### What changes did you make? (Give an overview)

Fixed `isDirectoryIgnored()` to always return `false` for the `basePath` directory.

#### Related Issues

refs https://github.com/eslint/eslint/issues/18706

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
