### PR TITLE
chore: upgrade `@types/eslint` to v9

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,7 @@ const eslintPluginJSDoc = eslintConfigESLint.find(
 
 export default [
 	{
-		ignores: ["**/tests/fixtures/", "**/dist/"],
+		ignores: ["**/tests/fixtures/", "**/dist/", "**/coverage/"],
 	},
 
 	...eslintConfigESLint,

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -48,7 +48,7 @@
   },
   "homepage": "https://github.com/eslint/rewrite#readme",
   "devDependencies": {
-    "@types/eslint": "^8.56.10",
+    "@types/eslint": "^9.6.0",
     "c8": "^9.1.0",
     "eslint": "^9.0.0",
     "mocha": "^10.4.0",

--- a/packages/compat/src/fixup-rules.js
+++ b/packages/compat/src/fixup-rules.js
@@ -9,7 +9,7 @@
 
 /** @typedef {import("eslint").ESLint.Plugin} FixupPluginDefinition */
 /** @typedef {import("eslint").Rule.RuleModule} FixupRuleDefinition */
-/** @typedef {import("eslint").Rule.OldStyleRule} FixupLegacyRuleDefinition */
+/** @typedef {FixupRuleDefinition["create"]} FixupLegacyRuleDefinition */
 /** @typedef {import("eslint").Linter.FlatConfig} FixupConfig */
 /** @typedef {Array<FixupConfig>} FixupConfigArray */
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/eslint/rewrite#readme",
   "devDependencies": {
-    "@types/eslint": "^8.56.10",
+    "@types/eslint": "^9.6.0",
     "eslint": "^9.0.0",
     "mocha": "^10.4.0",
     "typescript": "^5.4.5"

--- a/packages/migrate-config/package.json
+++ b/packages/migrate-config/package.json
@@ -37,7 +37,7 @@
   },
   "homepage": "https://github.com/eslint/rewrite#readme",
   "devDependencies": {
-    "@types/eslint": "^8.56.10",
+    "@types/eslint": "^9.6.0",
     "eslint": "^9.0.0",
     "mocha": "^10.4.0",
     "typescript": "^5.4.5"

--- a/packages/migrate-config/src/migrate-config.js
+++ b/packages/migrate-config/src/migrate-config.js
@@ -18,7 +18,7 @@ import { convertIgnorePatternToMinimatch } from "@eslint/compat";
 //-----------------------------------------------------------------------------
 
 /** @typedef {import("eslint").Linter.FlatConfig} FlatConfig */
-/** @typedef {import("eslint").Linter.Config} Config  */
+/** @typedef {import("eslint").Linter.LegacyConfig} LegacyConfig  */
 /** @typedef {import("eslint").Linter.ConfigOverride} ConfigOverride  */
 /** @typedef {import("recast").types.namedTypes.ObjectExpression} ObjectExpression */
 /** @typedef {import("recast").types.namedTypes.ArrayExpression} ArrayExpression */
@@ -51,7 +51,7 @@ const linterOptionsKeysToCopy = [
 class Migration {
 	/**
 	 * The config to migrate.
-	 * @type {Config}
+	 * @type {LegacyConfig}
 	 */
 	config;
 
@@ -81,7 +81,7 @@ class Migration {
 
 	/**
 	 * Creates a new Migration object.
-	 * @param {Config} config The config to migrate.
+	 * @param {LegacyConfig} config The config to migrate.
 	 */
 	constructor(config) {
 		this.config = config;
@@ -266,7 +266,7 @@ function createGitignoreEntry(migration) {
 
 /**
  * Creates the globals object from the config.
- * @param {Config} config The config to create globals from.
+ * @param {LegacyConfig} config The config to create globals from.
  * @returns {ObjectExpression|undefined} The globals object or undefined if none.
  */
 function createGlobals(config) {
@@ -380,7 +380,7 @@ function createGlobals(config) {
 
 /**
  * Creates the linter options object from the config.
- * @param {Config} config The config to create linter options from.
+ * @param {LegacyConfig} config The config to create linter options from.
  * @returns {ObjectExpression|undefined} The linter options object or undefined if none.
  */
 function createLinterOptions(config) {
@@ -454,7 +454,7 @@ function createFilesArray(patterns) {
 /**
  * Creates an object expression for the language options.
  * @param {Migration} migration The migration object.
- * @param {Config} config The config to create language options from.
+ * @param {LegacyConfig} config The config to create language options from.
  * @returns {ObjectExpression|undefined} The AST for the object expression or undefined if none.
  */
 function createLanguageOptions(migration, config) {
@@ -623,7 +623,7 @@ function createPlugins(plugins, migration) {
 
 /**
  * Creates an object expression for the `ignorePatterns` property.
- * @param {Config} config The config to create the object expression for.
+ * @param {LegacyConfig} config The config to create the object expression for.
  * @returns {ObjectExpression} The AST for the object expression.
  */
 function createGlobalIgnores(config) {
@@ -835,7 +835,7 @@ function migrateConfigObject(migration, config) {
 
 /**
  * Migrates an eslintrc config to flat config format.
- * @param {Config} config The eslintrc config to migrate.
+ * @param {LegacyConfig} config The eslintrc config to migrate.
  * @param {Object} [options] Options for the migration.
  * @param {"module"|"commonjs"} [options.sourceType] The module type to use.
  * @param {boolean} [options.gitignore] `true` to include contents of a .gitignore file.


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This PR upgrades `@types/eslint` to the last version for ESLint v9. `@types/eslint` is only included in `devDependencies` which makes this change a chore, even if the eslint types are referenced in the published type declarations of `@eslint/compat` and `@eslint/migrate-config`.

#### What changes did you make? (Give an overview)

* Updated the `@eslint/types` dependencies to `"^9.6.0"`.
* Updated a type import in `compat` package to work with both the v8 and v9 types.
* Replaced `Config` with `LegacyConfig` in `migrate-config` package to work with both the v8 and v9 types.
* Excluded c8-generated `coverage` directories from linting with eslint.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
