### PR TITLE
feat: Export ObjectSchema

### DIFF
--- a/packages/config-array/src/index.js
+++ b/packages/config-array/src/index.js
@@ -4,3 +4,4 @@
  */
 
 export { ConfigArray, ConfigArraySymbol } from "./config-array.js";
+export { ObjectSchema } from "@eslint/object-schema";


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Export `ObjectSchema` from the package. I'm working on some changes in the core where I need an instance of `ObjectSchema`, and even though the package is a dependency of `@eslint/config-array`, `@eslint/object-schema` isn't listed in `package.json`, which fails our lint check.

#### What changes did you make? (Give an overview)

Exported `ObjectSchema` as a passthrough from `@eslint/object-schema`.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
