### PR TITLE
feat: add CommonJS `core` types

### DIFF
--- a/packages/core/jsr.json
+++ b/packages/core/jsr.json
@@ -1,10 +1,11 @@
 {
   "name": "@eslint/core",
   "version": "0.3.0",
-  "exports": "./src/types.ts",
+  "exports": "./dist/esm/types.d.ts",
   "publish": {
     "include": [
-      "src/types.ts",
+      "dist/esm/types.d.ts",
+      "dist/cjs/types.d.cts",
       "README.md",
       "jsr.json",
       "LICENSE"

--- a/packages/core/jsr.json
+++ b/packages/core/jsr.json
@@ -5,7 +5,6 @@
   "publish": {
     "include": [
       "dist/esm/types.d.ts",
-      "dist/cjs/types.d.cts",
       "README.md",
       "jsr.json",
       "LICENSE"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,18 +3,22 @@
   "version": "0.3.0",
   "description": "Runtime-agnostic core of ESLint",
   "type": "module",
-  "types": "./src/types.ts",
+  "types": "./dist/esm/types.d.ts",
+  "exports": {
+    "types": {
+      "import": "./dist/esm/types.d.ts",
+      "require": "./dist/cjs/types.d.cts"
+    }
+  },
   "files": [
-    "src"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"
   },
-  "directories": {
-    "test": "tests"
-  },
   "scripts": {
-    "build": "tsc",
+    "build:cts": "node -e \"fs.cpSync('dist/esm/types.d.ts', 'dist/cjs/types.d.cts')\"",
+    "build": "tsc && npm run build:cts",
     "test:jsr": "npx jsr@latest publish --dry-run"
   },
   "repository": {
@@ -32,9 +36,6 @@
   },
   "homepage": "https://github.com/eslint/rewrite#readme",
   "devDependencies": {
-    "@types/eslint": "^9.6.0",
-    "eslint": "^9.0.0",
-    "mocha": "^10.4.0",
     "typescript": "^5.4.5"
   },
   "engines": {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Add CommonJS types to `@eslint/core`.

#### What changes did you make? (Give an overview)

I've added a build step that copies the generated `esm/types.d.ts` file to `cjs/types.d.cts` in the `dist` directory. Updated settings so that both `dist` files will be published to npm and JSR instead of the source file. This follows the pattern we are using in other packages in this repo.

I've verified that the new `.cts` module can be imported in `@types/eslint` when `@eslint/core` is added as a dependency.

#### Related Issues

fixes #95

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
