### PR TITLE
feat: make @types/eslint dependency public

### DIFF
--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -47,8 +47,10 @@
     "url": "https://github.com/eslint/rewrite/issues"
   },
   "homepage": "https://github.com/eslint/rewrite#readme",
+  "dependencies": {
+    "@types/eslint": "*"
+  },
   "devDependencies": {
-    "@types/eslint": "^9.6.0",
     "c8": "^9.1.0",
     "eslint": "^9.0.0",
     "mocha": "^10.4.0",


### PR DESCRIPTION
#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?

This package exports TS type definitions referring to eslint types, thus it should publicly include the `@types/eslint` package.

#### What changes did you make? (Give an overview)

In packages/compat/package.json, move "@types/eslint" to "dependencies".

#### Related Issues

fixes #105

#### Is there anything you'd like reviewers to focus on?
