### PR TITLE
docs: Add workaround if npx fails

### DIFF
--- a/packages/migrate-config/README.md
+++ b/packages/migrate-config/README.md
@@ -28,6 +28,13 @@ bunx @eslint/migrate-config .eslintrc.json
 
 The tool will automatically find your `.eslintignore` file in the same directory and migrate that into your new configuration file.
 
+If you receive any npm errors while running using `npx`, install the package manually first:
+
+```shell
+npm i @eslint/migrate-config
+npx @eslint-migrate-config .eslintrc.json
+```
+
 ### CommonJS Output
 
 By default, this tool generates an ESM file (`.mjs` extension). If you'd like to generate a CommonJS file instead, pass the `--commonjs` flag:

--- a/packages/migrate-config/README.md
+++ b/packages/migrate-config/README.md
@@ -32,7 +32,7 @@ If you receive any npm errors while running using `npx`, install the package man
 
 ```shell
 npm i @eslint/migrate-config
-npx @eslint-migrate-config .eslintrc.json
+npx @eslint/migrate-config .eslintrc.json
 ```
 
 ### CommonJS Output


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Adds instructions for what to do if the default `npx` command fails.

#### What changes did you make? (Give an overview)

Added mention to manually install the package if the default `npx` command fails.

#### Related Issues

Refs https://github.com/eslint/rewrite/issues/88
<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
