### PR TITLE
feat: Add rule types

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -58,7 +58,7 @@ export default [
 	// TypeScript
 	...tseslint.config({
 		files: ["**/*.ts"],
-		extends: [...tseslint.configs.strict],
+		extends: [...tseslint.configs.strict, ...tseslint.configs.stylistic],
 		rules: {
 			"no-use-before-define": "off",
 		},

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -58,7 +58,7 @@ export default [
 	// TypeScript
 	...tseslint.config({
 		files: ["**/*.ts"],
-		extends: [...tseslint.configs.strict, ...tseslint.configs.stylistic],
+		extends: [...tseslint.configs.strict],
 		rules: {
 			"no-use-before-define": "off",
 		},

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,6 +36,7 @@
   },
   "homepage": "https://github.com/eslint/rewrite#readme",
   "devDependencies": {
+    "json-schema": "^0.4.0",
     "typescript": "^5.4.5"
   },
   "engines": {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -269,7 +269,7 @@ export interface RuleContext<
 	 * The CommonJS path to the parser used while parsing this file.
 	 * @deprecated No longer used.
 	 */
-	parserPath: string;
+	parserPath: string | undefined;
 
 	/**
 	 * The rule ID.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -37,14 +37,6 @@ export interface FileProblem {
 //------------------------------------------------------------------------------
 
 /**
- * Represents an AST node or token with location information in ESLint format.
- */
-export interface SyntaxElement {
-	loc: SourceLocation;
-	range: SourceRange;
-}
-
-/**
  * Represents the start and end coordinates of a node inside the source.
  */
 export interface SourceLocation {
@@ -281,13 +273,16 @@ export interface RuleContext {
 /**
  * Manager of text edits for a rule fix.
  */
-export interface RuleTextEditor {
+export interface RuleTextEditor<EditableSyntaxElement = unknown> {
 	/**
 	 * Inserts text after the specified node or token.
-	 * @param nodeOrToken The node or token to insert after.
+	 * @param syntaxElement The node or token to insert after.
 	 * @param text The edit to insert after the node or token.
 	 */
-	insertTextAfter(nodeOrToken: object, text: string): RuleTextEdit;
+	insertTextAfter(
+		syntaxElement: EditableSyntaxElement,
+		text: string,
+	): RuleTextEdit;
 
 	/**
 	 * Inserts text after the specified range.
@@ -298,10 +293,13 @@ export interface RuleTextEditor {
 
 	/**
 	 * Inserts text before the specified node or token.
-	 * @param nodeOrToken The node or token to insert before.
+	 * @param syntaxElement A syntax element with location information to insert before.
 	 * @param text The edit to insert before the node or token.
 	 */
-	insertTextBefore(nodeOrToken: object, text: string): RuleTextEdit;
+	insertTextBefore(
+		syntaxElement: EditableSyntaxElement,
+		text: string,
+	): RuleTextEdit;
 
 	/**
 	 * Inserts text before the specified range.
@@ -312,10 +310,10 @@ export interface RuleTextEditor {
 
 	/**
 	 * Removes the specified node or token.
-	 * @param nodeOrToken The node or token to remove.
+	 * @param syntaxElement A syntax element with location information to remove.
 	 * @returns The edit to remove the node or token.
 	 */
-	remove(nodeOrToken: object): RuleTextEdit;
+	remove(syntaxElement: EditableSyntaxElement): RuleTextEdit;
 
 	/**
 	 * Removes the specified range.
@@ -326,11 +324,14 @@ export interface RuleTextEditor {
 
 	/**
 	 * Replaces the specified node or token with the given text.
-	 * @param nodeOrToken The node or token to replace.
+	 * @param syntaxElement A syntax element with location information to replace.
 	 * @param text The text to replace the node or token with.
 	 * @returns The edit to replace the node or token.
 	 */
-	replaceText(nodeOrToken: object, text: string): RuleTextEdit;
+	replaceText(
+		syntaxElement: EditableSyntaxElement,
+		text: string,
+	): RuleTextEdit;
 
 	/**
 	 * Replaces the specified range with the given text.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -167,11 +167,6 @@ export interface RulesMeta {
 	messages: Record<string, string>;
 
 	/**
-	 * The visitor keys for the rule.
-	 */
-	visitorKeys?: Record<string, string[]>;
-
-	/**
 	 * The deprecated rules for the rule.
 	 */
 	deprecated?: boolean | undefined;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -188,6 +188,7 @@ export interface RuleContext<
 	LangOptions = LanguageOptions,
 	Code extends SourceCode = SourceCode,
 	RuleOptions = unknown[],
+	Node = unknown,
 > {
 	/**
 	 * The current working directory for the session.
@@ -269,7 +270,7 @@ export interface RuleContext<
 	 * The report function that the rule should use to report problems.
 	 * @param violation The violation to report.
 	 */
-	report(violation: ViolationReport): void;
+	report(violation: ViolationReport<Node>): void;
 }
 
 // #region Rule Fixing
@@ -392,11 +393,11 @@ interface ViolationReportBase {
 }
 
 type ViolationMessage = { message: string } | { messageId: string };
-type ViolationLocation = { loc: SourceLocation } | { node: object };
+type ViolationLocation<Node> = { loc: SourceLocation } | { node: Node };
 
-export type ViolationReport = ViolationReportBase &
+export type ViolationReport<Node = unknown> = ViolationReportBase &
 	ViolationMessage &
-	ViolationLocation;
+	ViolationLocation<Node>;
 
 // #region Suggestions
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -185,8 +185,9 @@ export interface RulesMeta {
  * view into the outside world.
  */
 export interface RuleContext<
-	Code extends SourceCode = SourceCode,
 	LangOptions = LanguageOptions,
+	Code extends SourceCode = SourceCode,
+	RuleOptions = unknown[],
 > {
 	/**
 	 * The current working directory for the session.
@@ -262,7 +263,7 @@ export interface RuleContext<
 	/**
 	 * The rule's configured options.
 	 */
-	options: unknown[];
+	options: RuleOptions;
 
 	/**
 	 * The report function that the rule should use to report problems.
@@ -428,9 +429,10 @@ export type SuggestedEdit = SuggestedEditBase & SuggestionMessage;
  * The definition of an ESLint rule.
  */
 export interface RuleDefinition<
-	Visitor extends RuleVisitor = RuleVisitor,
-	Code extends SourceCode = SourceCode,
 	LangOptions = LanguageOptions,
+	Code extends SourceCode = SourceCode,
+	RuleOptions = unknown[],
+	Visitor extends RuleVisitor = RuleVisitor,
 > {
 	/**
 	 * The meta information for the rule.
@@ -442,7 +444,7 @@ export interface RuleDefinition<
 	 * @param context The rule context.
 	 * @returns The rule visitor.
 	 */
-	create(context: RuleContext<Code, LangOptions>): Visitor;
+	create(context: RuleContext<LangOptions, Code, RuleOptions>): Visitor;
 }
 
 //------------------------------------------------------------------------------

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -396,7 +396,7 @@ interface ViolationReportBase {
 	 */
 	fix?(
 		fixer: RuleTextEditor,
-	): RuleTextEdit | RuleTextEdit[] | IterableIterator<RuleTextEdit> | null;
+	): RuleTextEdit | Iterable<RuleTextEdit> | null;
 
 	/**
 	 * An array of suggested fixes for the problem. These fixes may change the

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -250,7 +250,7 @@ export interface RuleContext<
 	/**
 	 * Shared settings for the configuration.
 	 */
-	settings: Record<string, unknown>;
+	settings: SettingsConfig;
 
 	/**
 	 * Parser-specific options for the configuration.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -427,7 +427,7 @@ interface SuggestedEditBase {
 	 */
 	fix?(
 		fixer: RuleTextEditor,
-	): RuleTextEdit | RuleTextEdit[] | IterableIterator<RuleTextEdit> | null;
+	): RuleTextEdit | Iterable<RuleTextEdit> | null;
 }
 
 type SuggestionMessage = { desc: string } | { messageId: string };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -102,9 +102,7 @@ export interface RuleVisitor {
 	/**
 	 * Called for each node in the AST or at specific times during the traversal.
 	 */
-	[key: string]:
-		| ((node: unknown, parent?: unknown) => void)
-		| ((...unknown: unknown[]) => void);
+	[key: string]: (...args: unknown[]) => void;
 }
 /* eslint-enable @typescript-eslint/consistent-indexed-object-style -- Needs to be interface so people can extend it. */
 
@@ -850,7 +848,14 @@ export interface BinarySourceCode<
 	body: Uint8Array;
 }
 
-export type SourceCode = TextSourceCode | BinarySourceCode;
+export type SourceCode<
+	Options extends SourceCodeBaseTypeOptions = {
+		LangOptions: LanguageOptions;
+		RootNode: unknown;
+		SyntaxElementWithLoc: unknown;
+		ConfigNode: unknown;
+	},
+> = TextSourceCode<Options> | BinarySourceCode<Options>;
 
 /**
  * Represents a traversal step visiting the AST.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -434,6 +434,7 @@ export interface RuleDefinition<
 	Code extends SourceCode = SourceCode,
 	RuleOptions = unknown[],
 	Visitor extends RuleVisitor = RuleVisitor,
+	Node = unknown,
 > {
 	/**
 	 * The meta information for the rule.
@@ -445,7 +446,7 @@ export interface RuleDefinition<
 	 * @param context The rule context.
 	 * @returns The rule visitor.
 	 */
-	create(context: RuleContext<LangOptions, Code, RuleOptions>): Visitor;
+	create(context: RuleContext<LangOptions, Code, RuleOptions, Node>): Visitor;
 }
 
 //------------------------------------------------------------------------------

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -93,6 +93,7 @@ export type RuleType = "problem" | "suggestion" | "layout";
 export type RuleFixType = "code" | "whitespace";
 
 /* eslint-disable @typescript-eslint/consistent-indexed-object-style -- Needs to be interface so people can extend it. */
+/* eslint-disable @typescript-eslint/no-explicit-any -- Necessary to allow subclasses to work correctly */
 /**
  * An object containing visitor information for a rule. Each method is either the
  * name of a node type or a selector, or is a method that will be called at specific
@@ -102,9 +103,10 @@ export interface RuleVisitor {
 	/**
 	 * Called for each node in the AST or at specific times during the traversal.
 	 */
-	[key: string]: (...args: unknown[]) => void;
+	[key: string]: (...args: any[]) => void;
 }
 /* eslint-enable @typescript-eslint/consistent-indexed-object-style -- Needs to be interface so people can extend it. */
+/* eslint-enable @typescript-eslint/no-explicit-any -- Necessary to allow subclasses to work correctly */
 
 /**
  * Rule meta information used for documentation.
@@ -157,7 +159,7 @@ export interface RulesMeta<
 	/**
 	 * The messages that the rule can report.
 	 */
-	messages: Record<MessageIds, string>;
+	messages?: Record<MessageIds, string>;
 
 	/**
 	 * The deprecated rules for the rule.
@@ -394,9 +396,7 @@ interface ViolationReportBase {
 	 * @param fixer The text editor to apply the fix.
 	 * @returns The fix(es) for the violation.
 	 */
-	fix?(
-		fixer: RuleTextEditor,
-	): RuleTextEdit | Iterable<RuleTextEdit> | null;
+	fix?(fixer: RuleTextEditor): RuleTextEdit | Iterable<RuleTextEdit> | null;
 
 	/**
 	 * An array of suggested fixes for the problem. These fixes may change the
@@ -425,9 +425,7 @@ interface SuggestedEditBase {
 	 * @param fixer The text editor to apply the fix.
 	 * @returns The fix for the suggestion.
 	 */
-	fix?(
-		fixer: RuleTextEditor,
-	): RuleTextEdit | Iterable<RuleTextEdit> | null;
+	fix?(fixer: RuleTextEditor): RuleTextEdit | Iterable<RuleTextEdit> | null;
 }
 
 type SuggestionMessage = { desc: string } | { messageId: string };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -546,7 +546,14 @@ export interface LanguageTypeOptions {
 /**
  * Represents a plugin language.
  */
-export interface Language<Options extends LanguageTypeOptions> {
+export interface Language<
+	Options extends LanguageTypeOptions = {
+		LangOptions: LanguageOptions;
+		Code: SourceCode;
+		RootNode: unknown;
+		Node: unknown;
+	},
+> {
 	/**
 	 * Indicates how ESLint should read the file.
 	 */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -100,6 +100,7 @@ export type RuleType = "problem" | "suggestion" | "layout";
  */
 export type RuleFixType = "code" | "whitespace";
 
+/* eslint-disable @typescript-eslint/consistent-indexed-object-style -- Needs to be interface so people can extend it. */
 /**
  * An object containing visitor information for a rule. Each method is either the
  * name of a node type or a selector, or is a method that will be called at specific
@@ -113,6 +114,7 @@ export interface RuleVisitor {
 		| ((node: unknown, parent?: unknown) => void)
 		| ((...unknown: unknown[]) => void);
 }
+/* eslint-enable @typescript-eslint/consistent-indexed-object-style -- Needs to be interface so people can extend it. */
 
 /**
  * Rule meta information used for documentation.
@@ -386,7 +388,7 @@ interface ViolationReportBase {
 	 * An array of suggested fixes for the problem. These fixes may change the
 	 * behavior of the code, so they are not applied automatically.
 	 */
-	suggest?: Array<SuggestedEdit>;
+	suggest?: SuggestedEdit[];
 }
 
 type ViolationMessage = { message: string } | { messageId: string };


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Add types for rules that will work regardless of the language being used.

#### What changes did you make? (Give an overview)

I added several types that let us completely type check rules. These types are as generic as possible to allow for language plugins to override or better define their types, too.

These are *not* guaranteed to match the types in `@types/eslint`, which are very specific to the JavaScript language. The intent is to define something that will work and then see if we can backport into `@types/eslint` in a way that still works with the JavaScript rules.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

Does the naming make sense for the types? I tried to be more specific to avoid ambiguity (i.e., `RuleFixer` is now `RuleTextEditor`).

<!-- markdownlint-disable-file MD004 -->
