### PR TITLE
chore: remove `release-as` for plugin-kit

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -48,7 +48,6 @@
     },
     "packages/plugin-kit": {
       "release-type": "node",
-      "release-as": "0.1.0",
       "extra-files": [
         {
           "type": "json",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Removes hardcoded version of `@eslint/plugin-kit` from the release-please config so that the next version of this package can be released.

#### What changes did you make? (Give an overview)

Updated `release-please-config.json`.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
