### PR TITLE
fix: Support legacy `schema` properties

### DIFF
--- a/packages/compat/src/fixup-rules.js
+++ b/packages/compat/src/fixup-rules.js
@@ -183,6 +183,21 @@ export function fixupRule(ruleDefinition) {
 		create: ruleCreate,
 	};
 
+	// copy `schema` property of function-style rule or top-level `schema` property of object-style rule into `meta` object
+	// @ts-ignore -- top-level `schema` property was not offically supported for object-style rules so it doesn't exist in types
+	const { schema } = ruleDefinition;
+	if (schema) {
+		if (!newRuleDefinition.meta) {
+			newRuleDefinition.meta = { schema };
+		} else {
+			newRuleDefinition.meta = {
+				...newRuleDefinition.meta,
+				// top-level `schema` had precedence over `meta.schema` so it's okay to overwrite `meta.schema` if it exists
+				schema,
+			};
+		}
+	}
+
 	// cache the fixed up rule
 	fixedUpRuleReplacements.set(ruleDefinition, newRuleDefinition);
 	fixedUpRules.add(newRuleDefinition);


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Updates `@eslint/compat` utility to support legacy `schema` property of rules.

#### What changes did you make? (Give an overview)

Updated `fixupRule()` to copy top-level `schema` property into rule's `meta` object.

This covers:

* Legacy function-style rules, which were allowed to specify schema as `schema` property of the function.
* Object-style rules that were mistakenly specifying schema as top-level `schema` property, which was never officially supported but used to work in ESLint < 9.

#### Related Issues

Fixes #127

I tested this with `eslint-plugin-fp` and `eslint-plugin-filenames` rules mentioned in the original issue.

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
