### PR TITLE
fix: non-optional properties in generic interfaces

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -186,10 +186,10 @@ export interface RulesMeta<
  * Generic type for `RuleContext`.
  */
 export interface RuleContextTypeOptions {
-	LangOptions?: LanguageOptions;
-	Code?: SourceCode;
-	RuleOptions?: unknown[];
-	Node?: unknown;
+	LangOptions: LanguageOptions;
+	Code: SourceCode;
+	RuleOptions: unknown[];
+	Node: unknown;
 }
 
 /**
@@ -441,13 +441,13 @@ export type SuggestedEdit = SuggestedEditBase & SuggestionMessage;
  * Generic options for the `RuleDefinition` type.
  */
 export interface RuleDefinitionTypeOptions {
-	LangOptions?: LanguageOptions;
-	Code?: SourceCode;
-	RuleOptions?: unknown[];
-	Visitor?: RuleVisitor;
-	Node?: unknown;
-	MessageIds?: string;
-	ExtRuleDocs?: unknown;
+	LangOptions: LanguageOptions;
+	Code: SourceCode;
+	RuleOptions: unknown[];
+	Visitor: RuleVisitor;
+	Node: unknown;
+	MessageIds: string;
+	ExtRuleDocs: unknown;
 }
 
 /**
@@ -535,9 +535,9 @@ export type RulesConfig = Record<string, RuleConfig>;
  * Generic options for the `Language` type.
  */
 export interface LanguageTypeOptions {
-	LangOptions?: LanguageOptions;
-	Code?: SourceCode;
-	RootNode?: unknown;
+	LangOptions: LanguageOptions;
+	Code: SourceCode;
+	RootNode: unknown;
 	Node: unknown;
 }
 
@@ -733,10 +733,10 @@ interface InlineConfigElement {
  * Generic options for the `SourceCodeBase` type.
  */
 interface SourceCodeBaseTypeOptions {
-	LangOptions?: LanguageOptions;
-	RootNode?: unknown;
-	SyntaxElementWithLoc?: unknown;
-	ConfigNode?: unknown;
+	LangOptions: LanguageOptions;
+	RootNode: unknown;
+	SyntaxElementWithLoc: unknown;
+	ConfigNode: unknown;
 }
 
 /**


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

-   [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Fix a bug in the types.

#### What changes did you make? (Give an overview)

This PR fixes the type integration tests in ESLint which would currently fail with `@eslint/core@0.8.0` (eslint/eslint#19098).

The fix consists in marking the properties of generic interfaces as non-optional, meaning that they can't be `undefined`. These properties are only used to refer to a type. For example there is no actual object with a property `MessageIds`, but `RuleDefinitionTypeOptions["MessageIds"]` is used as an alias for `string`. If a union with `undefined` is desired, it can always be indicated explicitly as `RuleDefinitionTypeOptions["MessageIds"] | undefined`.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

refs eslint/eslint#19098

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
