### PR TITLE
feat: Check messageIds in context.report()

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -187,6 +187,7 @@ export interface RuleContextTypeOptions {
 	Code: SourceCode;
 	RuleOptions: unknown[];
 	Node: unknown;
+	MessageIds: string;
 }
 
 /**
@@ -195,12 +196,7 @@ export interface RuleContextTypeOptions {
  * view into the outside world.
  */
 export interface RuleContext<
-	Options extends RuleContextTypeOptions = {
-		LangOptions: LanguageOptions;
-		Code: SourceCode;
-		RuleOptions: unknown[];
-		Node: unknown;
-	},
+	Options extends RuleContextTypeOptions = RuleContextTypeOptions,
 > {
 	/**
 	 * The current working directory for the session.
@@ -282,7 +278,9 @@ export interface RuleContext<
 	 * The report function that the rule should use to report problems.
 	 * @param violation The violation to report.
 	 */
-	report(violation: ViolationReport<Options["Node"]>): void;
+	report(
+		violation: ViolationReport<Options["Node"], Options["MessageIds"]>,
+	): void;
 }
 
 // #region Rule Fixing
@@ -402,11 +400,16 @@ interface ViolationReportBase {
 	suggest?: SuggestedEdit[];
 }
 
-type ViolationMessage = { message: string } | { messageId: string };
+type ViolationMessage<MessageIds = string> =
+	| { message: string }
+	| { messageId: MessageIds };
 type ViolationLocation<Node> = { loc: SourceLocation } | { node: Node };
 
-export type ViolationReport<Node = unknown> = ViolationReportBase &
-	ViolationMessage &
+export type ViolationReport<
+	Node = unknown,
+	MessageIds = string,
+> = ViolationReportBase &
+	ViolationMessage<MessageIds> &
 	ViolationLocation<Node>;
 
 // #region Suggestions
@@ -469,6 +472,7 @@ export interface RuleDefinition<
 			Code: Options["Code"];
 			RuleOptions: Options["RuleOptions"];
 			Node: Options["Node"];
+			MessageIds: Options["MessageIds"];
 		}>,
 	): Options["Visitor"];
 }

--- a/packages/core/tests/types/types.test.ts
+++ b/packages/core/tests/types/types.test.ts
@@ -177,11 +177,14 @@ interface TestRuleVisitor extends RuleVisitor {
 	Node?: (node: TestNode) => void;
 }
 
+type TestMessageIds = "badFoo" | "wrongBar";
+
 type TestRuleContext = RuleContext<{
 	LangOptions: TestLanguageOptions;
 	Code: TestSourceCode;
 	RuleOptions: [{ foo: string; bar: number }];
 	Node: TestNode;
+	MessageIds: TestMessageIds;
 }>;
 
 const testRule: RuleDefinition<{


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

I realized we could easily type check `messageId` in `context.report()` if we pass through the `MessageIds` type from `RuleDefinition`, so I did that.

#### What changes did you make? (Give an overview)

Enhancements to `RuleContext` and related types:

* Added `MessageIds` to `RuleContextTypeOptions` to support custom message identifiers.
* Simplified the `RuleContext` interface by using `RuleContextTypeOptions` directly.
* Updated the `report` method in `RuleContext` to include `MessageIds` in the `ViolationReport` type.
* Enhanced `ViolationMessage` and `ViolationReport` types to support custom `MessageIds`.
* Included `MessageIds` in the `RuleDefinition` context options.

Test updates:

* Added `TestMessageIds` type and included it in `TestRuleContext` to validate the changes in the test suite.


#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
