### PR TITLE
feat: allow unsafely customise META_FIELDS

### DIFF
--- a/packages/config-array/tests/config-array.test.js
+++ b/packages/config-array/tests/config-array.test.js
@@ -3316,6 +3316,54 @@ describe("ConfigArray", () => {
 				);
 				assert.deepStrictEqual(configs.ignores, ["ignoreme"]);
 			});
+
+			it("should not count global ignores when there are extra fields except for those match metaFields", () => {
+				configs = new ConfigArray(
+					[
+						{
+							name: "foo",
+							ignores: ["ignoreme"],
+							extraField: "EXTRA",
+						},
+					],
+					{
+						basePath,
+					},
+				);
+
+				configs.normalizeSync();
+
+				assert.strictEqual(
+					configs.isFileIgnored("ignoreme/foo/bar.js"),
+					false,
+				);
+				assert.deepStrictEqual(configs.ignores, []);
+			});
+
+			it("should not count global ignores when there are extra fields except for those match metaFields", () => {
+				configs = new ConfigArray(
+					[
+						{
+							name: "foo",
+							ignores: ["ignoreme"],
+							extraField: "EXTRA",
+						},
+					],
+					{
+						basePath,
+						// eslint-disable-next-line camelcase -- unsafe field assignment
+						UNSAFE_extraMetaFields: ["extraField"],
+					},
+				);
+
+				configs.normalizeSync();
+
+				assert.strictEqual(
+					configs.isFileIgnored("ignoreme/bar/foo.js"),
+					true,
+				);
+				assert.deepStrictEqual(configs.ignores, ["ignoreme"]);
+			});
 		});
 
 		describe("push()", () => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Currently config array assumes `name` is the only meta field that should be treated as descriptive information when checking ignore and matching configs.

However, in certain scenarios, we should allow customization of the default `META_FIELDS`.

#### What changes did you make? (Give an overview)

Expose an `UNSAFE_extraMetaFields`, which will be combined with `const META_FIELDS` as the instance's `this.metaFields`, which will be used everywhere instead of `const META_FIELDS`.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->
N/A

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
N/A
