### PR TITLE
fix: Make meta.replacedBy read only

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -166,7 +166,7 @@ export interface RulesMeta<
 	/**
 	 * When a rule is deprecated, indicates the rule ID(s) that should be used instead.
 	 */
-	replacedBy?: string[] | undefined;
+	replacedBy?: readonly string[] | undefined;
 
 	/**
 	 * Indicates if the rule is fixable, and if so, what type of fix it provides.


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Make compatibility changes to `RuleDefinition`

#### What changes did you make? (Give an overview)

Changed `meta.replacedBy` from `string[] | undefined` to `readonly string[] | undefined` to be backwards-compatible with the definitions in `@types/eslint`.

#### Related Issues

related to https://github.com/eslint/eslint/pull/19157#issuecomment-2619837426

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
