### PR TITLE
feat: Update RuleDefinition with `meta.defaultOptions`

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -158,6 +158,9 @@ export interface RulesMeta<
 	 */
 	schema?: JSONSchema4 | JSONSchema4[] | false | undefined;
 
+	/** Any default options to be recursively merged on top of any user-provided options. */
+	defaultOptions?: unknown[];
+
 	/**
 	 * The messages that the rule can report.
 	 */

--- a/packages/core/tests/types/types.test.ts
+++ b/packages/core/tests/types/types.test.ts
@@ -217,6 +217,21 @@ const testRule: RuleDefinition<{
 				},
 			],
 		},
+		schema: [
+			{
+				type: "object",
+				properties: {
+					foo: {
+						type: "string",
+					},
+					bar: {
+						type: "integer",
+					},
+				},
+				additionalProperties: false,
+			},
+		],
+		defaultOptions: [{ foo: "always", bar: 5 }],
 		messages: {
 			badFoo: "change this foo",
 			wrongBar: "fix this bar",
@@ -227,21 +242,23 @@ const testRule: RuleDefinition<{
 		return {
 			Foo(node: TestNode) {
 				// node.type === "Foo"
-				context.report({
-					messageId: "badFoo",
-					loc: {
-						start: { line: node.start, column: 1 },
-						end: { line: node.start + 1, column: Infinity },
-					},
-					fix(fixer: RuleTextEditor): RuleTextEdit {
-						return fixer.replaceText(
-							node,
-							context.languageOptions.howMuch === "yes"
-								? "👍"
-								: "👎",
-						);
-					},
-				});
+				if (context.options[0].foo === "always") {
+					context.report({
+						messageId: "badFoo",
+						loc: {
+							start: { line: node.start, column: 1 },
+							end: { line: node.start + 1, column: Infinity },
+						},
+						fix(fixer: RuleTextEditor): RuleTextEdit {
+							return fixer.replaceText(
+								node,
+								context.languageOptions.howMuch === "yes"
+									? "👍"
+									: "👎",
+							);
+						},
+					});
+				}
 			},
 			Bar(node: TestNode) {
 				// node.type === "Bar"


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Adds `defaultOptions` to `RulesMeta` in `@eslint/core` types. 

#### What changes did you make? (Give an overview)

Copied this:

https://github.com/eslint/eslint/blob/758c66bc8d83cd4eda9639b0745f0d0fb70f04f4/lib/types/index.d.ts#L744-L745

Also added `schema`, `defaultOptions`, and `context.options` in tests.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

https://github.com/eslint/eslint/pull/17656

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
