### PR TITLE
chore: Add publish script

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -47,6 +47,29 @@ jobs:
               if: ${{ steps.release.outputs.releases_created == 'true' }}
 
             #-----------------------------------------------------------------------------
+            # NOTE: This script currently doesn't do anything. It just outputs the
+            # release information to the console. We will do this for a few releases
+            # to make sure everything is working correctly before we switch to use this
+            # script exclusively.
+            #-----------------------------------------------------------------------------
+
+            - name: Publish using new script
+              run: node scripts/publish.js --dry-run
+              if: ${{ steps.release.outputs.releases_created == 'true' }}
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+                  TWITTER_API_CONSUMER_KEY: ${{ secrets.TWITTER_CONSUMER_KEY }}
+                  TWITTER_API_CONSUMER_SECRET: ${{ secrets.TWITTER_CONSUMER_SECRET }}
+                  TWITTER_ACCESS_TOKEN_KEY: ${{ secrets.TWITTER_ACCESS_TOKEN_KEY }}
+                  TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+                  MASTODON_ACCESS_TOKEN: ${{ secrets.MASTODON_ACCESS_TOKEN }}
+                  MASTODON_HOST: ${{ secrets.MASTODON_HOST }}
+                  BLUESKY_IDENTIFIER: ${{ vars.BLUESKY_IDENTIFIER }}
+                  BLUESKY_PASSWORD: ${{ secrets.BLUESKY_PASSWORD }}
+                  BLUESKY_HOST: ${{ vars.BLUESKY_HOST }}
+
+            #-----------------------------------------------------------------------------
             # NOTE: Packages are released in order of dependency. The packages with the
             # fewest internal dependencies are released first and the packages with the
             # most internal dependencies are released last.

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -57,6 +57,7 @@ jobs:
               run: node scripts/publish.js --dry-run
               if: ${{ steps.release.outputs.releases_created == 'true' }}
               env:
+                  STEPS_RELEASE_OUTPUTS: ${{ toJson(steps.release.outputs) }}
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
                   TWITTER_API_CONSUMER_KEY: ${{ secrets.TWITTER_CONSUMER_KEY }}

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -30,7 +30,7 @@ const PACKAGES_DIR = path.resolve(__dirname, "..", "packages");
  * Gets a list of directories in the packages directory.
  * @returns {Promise<string[]>} A promise that resolves with an array of package directories.
  */
-async function getPackageDirs() {
+export async function getPackageDirs() {
 	const packageDirs = await fsp.readdir(PACKAGES_DIR);
 	return packageDirs.map(entry => `packages/${entry}`);
 }
@@ -40,7 +40,7 @@ async function getPackageDirs() {
  * @param {Array<string>} packageDirs An array of package directories.
  * @returns {Map<string, Set<string>>} A map of package names to the set of dependencies.
  */
-async function calculatePackageDependencies(packageDirs) {
+export async function calculatePackageDependencies(packageDirs) {
 	return new Map(
 		await Promise.all(
 			packageDirs.map(async packageDir => {
@@ -78,7 +78,7 @@ async function calculatePackageDependencies(packageDirs) {
  * dependencies between packages.
  * @returns {Array<string>} An array of directories to be built in order.
  */
-function createBuildOrder(dependencies) {
+export function createBuildOrder(dependencies) {
 	const buildOrder = [];
 	const seen = new Set();
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -10,97 +10,15 @@
 //------------------------------------------------------------------------------
 
 import { execSync } from "node:child_process";
-import path from "node:path";
-import fsp from "node:fs/promises";
-import { fileURLToPath } from "node:url";
-
-//-----------------------------------------------------------------------------
-// Data
-//-----------------------------------------------------------------------------
-
-const __filename = fileURLToPath(import.meta.url); // eslint-disable-line no-underscore-dangle -- convention
-const __dirname = path.dirname(__filename); // eslint-disable-line no-underscore-dangle -- convention
-const PACKAGES_DIR = path.resolve(__dirname, "..", "packages");
+import {
+	getPackageDirs,
+	calculatePackageDependencies,
+	createBuildOrder,
+} from "./shared.js";
 
 //------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
-
-/**
- * Gets a list of directories in the packages directory.
- * @returns {Promise<string[]>} A promise that resolves with an array of package directories.
- */
-export async function getPackageDirs() {
-	const packageDirs = await fsp.readdir(PACKAGES_DIR);
-	return packageDirs.map(entry => `packages/${entry}`);
-}
-
-/**
- * Calculates the dependencies between packages.
- * @param {Array<string>} packageDirs An array of package directories.
- * @returns {Map<string, Set<string>>} A map of package names to the set of dependencies.
- */
-export async function calculatePackageDependencies(packageDirs) {
-	return new Map(
-		await Promise.all(
-			packageDirs.map(async packageDir => {
-				const packageJson = await fsp.readFile(
-					path.join(packageDir, "package.json"),
-					"utf8",
-				);
-				const pkg = JSON.parse(packageJson);
-				const dependencies = new Set();
-
-				if (pkg.dependencies) {
-					for (const dep of Object.keys(pkg.dependencies)) {
-						dependencies.add(dep);
-					}
-				}
-
-				if (pkg.devDependencies) {
-					for (const dep of Object.keys(pkg.devDependencies)) {
-						dependencies.add(dep);
-					}
-				}
-
-				return [
-					pkg.name,
-					{ name: pkg.name, dir: packageDir, dependencies },
-				];
-			}),
-		),
-	);
-}
-
-/**
- * Creates an array of directories to be built in order to satisfy dependencies.
- * @param {Map<string,{name:string,dir:string,dependencies:Set<string>}>} dependencies The
- * dependencies between packages.
- * @returns {Array<string>} An array of directories to be built in order.
- */
-export function createBuildOrder(dependencies) {
-	const buildOrder = [];
-	const seen = new Set();
-
-	function visit(name) {
-		if (!seen.has(name)) {
-			seen.add(name);
-
-			// we only need to deal with dependencies in this monorepo
-			if (dependencies.has(name)) {
-				const { dependencies: deps, dir } = dependencies.get(name);
-				deps.forEach(visit);
-				buildOrder.push(dir);
-			}
-		}
-	}
-
-	dependencies.forEach((value, key) => {
-		visit(key);
-	});
-
-	return buildOrder;
-}
 
 /**
  * Builds the packages in the correct order.

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -1,0 +1,207 @@
+/**
+ * @fileoverview Publishes all of the packages in dependency order
+ * via GitHub workflow.
+ *
+ * @author Nicholas C. Zakas
+ */
+
+
+//-----------------------------------------------------------------------------
+// Imports
+//-----------------------------------------------------------------------------
+
+import { getPackageDirs, calculatePackageDependencies, createBuildOrder } from "./build.js";
+import { execSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+//-----------------------------------------------------------------------------
+// Helpers
+//-----------------------------------------------------------------------------
+
+/**
+ * Converts a GitHub Actions step output name to its corresponding environment variable name
+ * @param {string} stepId The ID of the step
+ * @param {string} outputName The name of the output
+ * @returns {string} The environment variable name
+ */
+function convertOutputToEnvVar(stepId, outputName) {
+    // Convert step ID to uppercase and replace hyphens with underscores
+    const normalizedStepId = stepId.toUpperCase().replace(/-/gu, '_');
+
+    // Convert output name to uppercase and replace slashes with double underscores
+    const normalizedOutputName = outputName
+        .toUpperCase()
+        .replace(/\//gu, '__')
+        .replace(/-/gu, '_');
+
+    return `STEPS_${normalizedStepId}_OUTPUTS_${normalizedOutputName}`;
+}
+
+/**
+ * Gets the output of a GitHub Actions step from the environment variables.
+ * @param {string} packageDir The directory of the package.
+ * @param {string} name The name of the output.
+ * @return {string} The output value.
+ */
+function getReleaseOutput(packageDir, name) {
+    return process.env[convertOutputToEnvVar('release', `${packageDir}--${name}`)];
+}
+
+/**
+ * Gets the list of packages to publish.
+ * @param {Array<string>} packageDirs The list of package directories.
+ * @return {Array<string>} The list of packages to publish.
+ */
+function getPackagesToPublish(packageDirs) {    
+    return packageDirs.filter(packageDir => getReleaseOutput(packageDir, "release_created") === "true");
+}
+
+/**
+ * Publishes the packages to npm. If one package fails to publish, the rest
+ * will still be published.
+ * @param {Array<string>} packageDirs The list of package directories.
+ * @return {Map<string,boolean>} A map of package directory to whether it was published successfully.
+ */
+function publishPackagesToNpm(packageDirs) {
+    console.log(`Publishing packages to npm in this order: ${packageDirs.join(", ")}`);
+    
+    const results = new Map();
+
+    for (const packageDir of packageDirs) {
+        console.log(`Publishing ${packageDir}...`);
+        try {
+            execSync(`npm publish -w ${packageDir} --provenance`, {
+                stdio: "inherit",
+                env: process.env
+            });
+            
+            results.set(packageDir, "ok");
+        } catch (error) {
+            console.error(`Failed to publish ${packageDir} to npm`);
+            console.log(error.message);
+            
+            results.set(packageDir, error.message);
+        }
+    }
+
+    console.log("Done publishing packages to npm.");
+}
+
+/**
+ * Publishes the packages to JSR. If one package fails to publish, the rest
+ * will still be published.
+ * @param {Array<string>} packageDirs The list of package directories.
+ * @return {Map<string,boolean>} A map of package directory to whether it was published successfully.
+ **/
+function publishPackagesToJsr(packageDirs) {
+    console.log(`Publishing packages to JSR in this order: ${packageDirs.join(", ")}`);
+    
+    const results = new Map();
+
+    for (const packageDir of packageDirs) {
+        
+        // Skip if no jsr.json exists
+        if (!existsSync(join(packageDir, "jsr.json"))) {
+            console.log(`Skipping ${packageDir} (no jsr.json found)`);
+            results.set(packageDir, "ok (skipped)");
+            continue;
+        }
+
+        console.log(`Publishing ${packageDir}...`);
+        try {
+            execSync(`npx jsr publish`, {
+                stdio: "inherit",
+                env: process.env,
+                cwd: packageDir
+            });
+            
+            results.set(packageDir, "ok");
+        } catch (error) {
+            console.error(`Failed to publish ${packageDir} to npm`);
+            console.log(error.message);
+            
+            results.set(packageDir, error.message);
+        }
+    }
+
+    console.log("Done publishing packages to JSR.");
+    return results;
+}
+
+function postResultToSocialMedia(npmPublishResults) {
+
+    const messages = [];    
+
+    for (const [packageDir, result] of npmPublishResults.entries()) {
+        
+        if (result !== "ok") {
+            continue;
+        }
+        
+        const packageJson = JSON.parse(readFileSync(join(packageDir, "package.json"), "utf8"));
+        const packageName = packageJson.name.slice(1); // remove leading @
+        const packageVersion = packageJson.version;
+        
+        messages.push(`${packageName} v${packageVersion}\n${getReleaseOutput(packageDir, "html_url")}`);
+    }
+    
+    // group four messages per post to avoid post limits
+    const messageChunks = [];
+    for (let i = 0; i < messages.length; i += 4) {
+        messageChunks.push(messages.slice(i, i + 4).join("\n\n"));
+    }
+    
+    for (const messageChunk of messageChunks) {
+        const message = `Just released:\n\n${messageChunk}`;
+   
+        console.log(message);
+        
+        // execSync(`npx @humanwhocodes/crosspost -t -b -m ${JSON.stringify(message)}`, {
+        //     stdio: "inherit",
+        //     env: process.env
+        // });
+    }
+
+    console.log("Posted to social media.");
+}
+
+//-----------------------------------------------------------------------------
+// Main
+//-----------------------------------------------------------------------------
+
+const packageDirs = await getPackageDirs();
+const dependencies = await calculatePackageDependencies(packageDirs);
+const buildOrder = createBuildOrder(dependencies);
+const packagesToPublish = getPackagesToPublish(buildOrder);
+
+if (packagesToPublish.length === 0) {
+    console.log("No packages to publish.");
+    process.exit(0);
+}
+
+console.log("The following packages will be published:");
+console.log(packagesToPublish.join("\n"));
+
+const npmPublishResults = publishPackagesToNpm(packagesToPublish);
+const jsrPublishResults = publishPackagesToJsr(packagesToPublish);
+
+console.log("\nSummary of npm results:");
+console.log(
+    [...npmPublishResults.entries()]
+        .map(([dir, result]) => `- ${dir}: ${result}`)
+        .join("\n"),
+);
+
+console.log("\nSummary of JSR results:");
+console.log(
+    [...jsrPublishResults.entries()]
+        .map(([dir, result]) => `- ${dir}: ${result}`)
+        .join("\n"),
+);
+
+
+
+
+
+process.exitCode = [...npmPublishResults, ...jsrPublishResults].some(([, value]) => !value.startsWith("ok")) ? 1 : 0;

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -32,27 +32,19 @@ const dryRun = process.argv.includes("--dry-run");
 const exec = dryRun ? text => console.log(text) : execSync;
 
 //-----------------------------------------------------------------------------
-// Helpers
+// Read Step Output
 //-----------------------------------------------------------------------------
 
-/**
- * Converts a GitHub Actions step output name to its corresponding environment variable name
- * @param {string} stepId The ID of the step
- * @param {string} outputName The name of the output
- * @returns {string} The environment variable name
- */
-function convertOutputToEnvVar(stepId, outputName) {
-	// Convert step ID to uppercase and replace hyphens with underscores
-	const normalizedStepId = stepId.toUpperCase().replace(/-/gu, "_");
-
-	// Convert output name to uppercase and replace slashes with double underscores
-	const normalizedOutputName = outputName
-		.toUpperCase()
-		.replace(/\//gu, "__")
-		.replace(/-/gu, "_");
-
-	return `STEPS_${normalizedStepId}_OUTPUTS_${normalizedOutputName}`;
+if (!process.env.STEPS_RELEASE_OUTPUTS) {
+	console.error("No release outputs found.");
+	process.exit(1);
 }
+
+const releaseOutputs = JSON.parse(process.env.STEPS_RELEASE_OUTPUTS);
+
+//-----------------------------------------------------------------------------
+// Helpers
+//-----------------------------------------------------------------------------
 
 /**
  * Gets the output of a GitHub Actions step from the environment variables.
@@ -61,9 +53,7 @@ function convertOutputToEnvVar(stepId, outputName) {
  * @return {string} The output value.
  */
 function getReleaseOutput(packageDir, name) {
-	return process.env[
-		convertOutputToEnvVar("release", `${packageDir}--${name}`)
-	];
+	return releaseOutputs[`${packageDir}--${name}`];
 }
 
 /**

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -90,13 +90,7 @@ function mapDependenciesToPaths(dependencies) {
 	for (const [, { dir: packageDir, dependencies: deps }] of dependencies) {
 		const pathDeps = [...deps]
 			.filter(dep => dependencies.has(dep))
-			.map(dep => {
-				const depDir = dependencies.get(dep);
-				if (depDir) {
-					return depDir.dir;
-				}
-				return dep;
-			});
+			.map(dep => dependencies.get(dep).dir);
 		mappedDependencies.set(packageDir, new Set(pathDeps));
 	}
 
@@ -120,8 +114,13 @@ function publishPackagesToNpm(packageDirs, dependencies) {
 	for (const packageDir of packageDirs) {
 		// check if any dependencies previously failed
 		const deps = dependencies.get(packageDir);
+		const hasNotOkDeps =
+			deps &&
+			[...deps].some(
+				dep => results.has(dep) && results.get(dep) !== "ok",
+			);
 
-		if (deps && [...deps].some(dep => results.get(dep) !== "ok")) {
+		if (hasNotOkDeps) {
 			console.log(`Skipping ${packageDir} (missing dependencies)`);
 			results.set(packageDir, "Skipped (missing dependencies)");
 			continue;

--- a/scripts/shared.js
+++ b/scripts/shared.js
@@ -1,0 +1,100 @@
+/**
+ * @fileoverview Common utilities for scripts.
+ * @author Nicholas C. Zakas
+ */
+
+//-----------------------------------------------------------------------------
+// Imports
+//-----------------------------------------------------------------------------
+
+import path from "node:path";
+import fsp from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+//-----------------------------------------------------------------------------
+// Data
+//-----------------------------------------------------------------------------
+
+const __filename = fileURLToPath(import.meta.url); // eslint-disable-line no-underscore-dangle -- convention
+const __dirname = path.dirname(__filename); // eslint-disable-line no-underscore-dangle -- convention
+const PACKAGES_DIR = path.resolve(__dirname, "..", "packages");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Gets a list of directories in the packages directory.
+ * @returns {Promise<string[]>} A promise that resolves with an array of package directories.
+ */
+export async function getPackageDirs() {
+	const packageDirs = await fsp.readdir(PACKAGES_DIR);
+	return packageDirs.map(entry => `packages/${entry}`);
+}
+
+/**
+ * Calculates the dependencies between packages.
+ * @param {Array<string>} packageDirs An array of package directories.
+ * @returns {Map<string, Set<string>>} A map of package names to the set of dependencies.
+ */
+export async function calculatePackageDependencies(packageDirs) {
+	return new Map(
+		await Promise.all(
+			packageDirs.map(async packageDir => {
+				const packageJson = await fsp.readFile(
+					path.join(packageDir, "package.json"),
+					"utf8",
+				);
+				const pkg = JSON.parse(packageJson);
+				const dependencies = new Set();
+
+				if (pkg.dependencies) {
+					for (const dep of Object.keys(pkg.dependencies)) {
+						dependencies.add(dep);
+					}
+				}
+
+				if (pkg.devDependencies) {
+					for (const dep of Object.keys(pkg.devDependencies)) {
+						dependencies.add(dep);
+					}
+				}
+
+				return [
+					pkg.name,
+					{ name: pkg.name, dir: packageDir, dependencies },
+				];
+			}),
+		),
+	);
+}
+
+/**
+ * Creates an array of directories to be built in order to satisfy dependencies.
+ * @param {Map<string,{name:string,dir:string,dependencies:Set<string>}>} dependencies The
+ * dependencies between packages.
+ * @returns {Array<string>} An array of directories to be built in order.
+ */
+export function createBuildOrder(dependencies) {
+	const buildOrder = [];
+	const seen = new Set();
+
+	function visit(name) {
+		if (!seen.has(name)) {
+			seen.add(name);
+
+			// we only need to deal with dependencies in this monorepo
+			if (dependencies.has(name)) {
+				const { dependencies: deps, dir } = dependencies.get(name);
+				deps.forEach(visit);
+				buildOrder.push(dir);
+			}
+		}
+	}
+
+	dependencies.forEach((value, key) => {
+		visit(key);
+	});
+
+	return buildOrder;
+}


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Add a new script to simplify publishing packages.

#### What changes did you make? (Give an overview)

Added a new script that automatically calculates the correct publish order for packages in this repo. It also posts to social media once complete.

All npm packages are published first, followed by all JSR packages.

This should simplify publishing going forward and allow us to simplify the `release-please.yml` workflow.

For now, I've added this into `release-please.yml` in dry run mode so it just output the commands that it would otherwise execute. I figured we can do this for a couple of releases to ensure that the commands its intends to run are correct before switching over.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
