### PR TITLE
build: Add manual republish of packages

### DIFF
--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -1,0 +1,81 @@
+name: Manual Package Publish
+
+on:
+    workflow_dispatch:
+        inputs:
+            package:
+                description: "Package to publish"
+                required: true
+                type: choice
+                options:
+                    # NOTE: Package names are automatically generated. Do not manually edit.
+                    # packages-start
+                    - compat
+                    - config-array
+                    - core
+                    - migrate-config
+                    - object-schema
+                    - plugin-kit
+                    # packages-end
+
+permissions:
+    contents: read
+    id-token: write
+
+jobs:
+    publish:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: lts/*
+                  registry-url: "https://registry.npmjs.org"
+
+            - name: Install dependencies
+              run: npm install
+
+            - name: Get latest release tag
+              id: get-latest-release
+              run: |
+                  LATEST_TAG=$(git tag -l "${{ inputs.package }}*" --sort=-v:refname | head -n 1)
+                  echo "latest_tag=${LATEST_TAG}" >> $GITHUB_OUTPUT
+
+            - name: Check out latest release
+              id: checkout-latest-release
+              run: |
+                  git fetch --tags origin ${{ steps.get-latest-release.outputs.latest_tag }}
+                  git checkout ${{ steps.get-latest-release.outputs.latest_tag }}
+
+            - name: Get package version
+              id: get-version
+              run: |
+                  VERSION=$(node -p "require('./${{ inputs.package }}/package.json').version")
+                  echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+            - name: Build
+              run: npm run build
+
+            - name: Publish to npm
+              run: npm publish -w packages/${{ inputs.package }} --provenance
+              env:
+                  NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+
+            - name: Publish to JSR
+              if: ${{ inputs.package != 'migrate-config' }}
+              run: npx jsr publish
+              working-directory: packages/${{ inputs.package }}
+
+            - name: Post Release Announcement
+              run: npx @humanwhocodes/crosspost -t -b -m "eslint/${{ inputs.package }} v${{ steps.get-version.outputs.version }} has been released!\n\nhttps://github.com/eslint/rewrite/releases/tag/${{ steps.get-latest-release.outputs.latest_tag }}"
+              env:
+                  TWITTER_API_CONSUMER_KEY: ${{ secrets.TWITTER_CONSUMER_KEY }}
+                  TWITTER_API_CONSUMER_SECRET: ${{ secrets.TWITTER_CONSUMER_SECRET }}
+                  TWITTER_ACCESS_TOKEN_KEY: ${{ secrets.TWITTER_ACCESS_TOKEN_KEY }}
+                  TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+                  MASTODON_ACCESS_TOKEN: ${{ secrets.MASTODON_ACCESS_TOKEN }}
+                  MASTODON_HOST: ${{ secrets.MASTODON_HOST }}
+                  BLUESKY_IDENTIFIER: ${{ vars.BLUESKY_IDENTIFIER }}
+                  BLUESKY_PASSWORD: ${{ secrets.BLUESKY_PASSWORD }}
+                  BLUESKY_HOST: ${{ vars.BLUESKY_HOST }}

--- a/tools/new-pkg.js
+++ b/tools/new-pkg.js
@@ -133,6 +133,35 @@ issueTemplateFiles.forEach(file => {
 });
 
 //-----------------------------------------------------------------------------
+// Update manual-publish.yml
+//-----------------------------------------------------------------------------
+
+console.log("\nUpdating manual-publish.yml...");
+
+const publishPath = "./.github/workflows/manual-publish.yml";
+const publishContent = readFileSync(publishPath, "utf8");
+const publishLines = publishContent.split(/\r?\n/gu);
+const publishStartIndex = publishLines.findIndex(line =>
+	line.includes("# packages-start"),
+);
+const publishEndIndex = publishLines.findIndex(line =>
+	line.includes("# packages-end"),
+);
+const newPublishLines = packageNames.map(
+	packageName => `${" ".repeat(20)}- ${packageName}`,
+);
+
+publishLines.splice(
+	publishStartIndex + 1,
+	publishEndIndex - publishStartIndex - 1,
+	...newPublishLines,
+);
+
+writeFileSync(publishPath, publishLines.join("\n"), "utf8");
+
+console.log("✅ Updated", publishPath);
+
+//-----------------------------------------------------------------------------
 // Update README
 //-----------------------------------------------------------------------------
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Allow for manual republishing of packages.

#### What changes did you make? (Give an overview)

- Added a new `manual-publish.yml` file that can be triggered by workflow dispatch, which goes through these steps:
  1. Finds the latest tag for the given package
  2. Checks out the latest tag
  3. Reads the version number from `package.json`
  4. Publishes to npm
  5. Publishes to JSR
  6. Tweets out release
- Updated the new package tool to also edit `manual-publish.yml`

#### Related Issues

refs https://github.com/eslint/rewrite/issues/153

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
