### PR TITLE
fix: Types to align with older ESLint types

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -459,6 +459,15 @@ export interface RuleTextEdit {
 
 // #endregion
 
+/**
+ * Fixes a violation.
+ * @param fixer The text editor to apply the fix.
+ * @returns The fix(es) for the violation.
+ */
+type RuleFixer = (
+	fixer: RuleTextEditor,
+) => RuleTextEdit | Iterable<RuleTextEdit> | null;
+
 interface ViolationReportBase {
 	/**
 	 * The type of node that the violation is for.
@@ -476,19 +485,21 @@ interface ViolationReportBase {
 	 * @param fixer The text editor to apply the fix.
 	 * @returns The fix(es) for the violation.
 	 */
-	fix?(fixer: RuleTextEditor): RuleTextEdit | Iterable<RuleTextEdit> | null;
+	fix?: RuleFixer | null | undefined;
 
 	/**
 	 * An array of suggested fixes for the problem. These fixes may change the
 	 * behavior of the code, so they are not applied automatically.
 	 */
-	suggest?: SuggestedEdit[];
+	suggest?: SuggestedEdit[] | null | undefined;
 }
 
 type ViolationMessage<MessageIds = string> =
 	| { message: string }
 	| { messageId: MessageIds };
-type ViolationLocation<Node> = { loc: SourceLocation } | { node: Node };
+type ViolationLocation<Node> =
+	| { loc: SourceLocation | Position }
+	| { node: Node };
 
 export type ViolationReport<
 	Node = unknown,

--- a/packages/core/tests/types/types.test.ts
+++ b/packages/core/tests/types/types.test.ts
@@ -257,6 +257,7 @@ const testRule: RuleDefinition<{
 									: "👎",
 							);
 						},
+						suggest: undefined,
 					});
 				}
 			},
@@ -270,6 +271,15 @@ const testRule: RuleDefinition<{
 							messageId: "Bar",
 						},
 					],
+				});
+			},
+			Baz(node: TestNode) {
+				// node.type === "Baz"
+				context.report({
+					message: "This baz is foobar",
+					loc: { line: node.start, column: 1 },
+					fix: null,
+					suggest: null,
 				});
 			},
 		};


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Fix the type definitions for `RuleContext` to align with older `@types/eslint` types.

#### What changes did you make? (Give an overview)

* [`packages/core/src/types.ts`](diffhunk://#diff-4c2458380e50c967c70d7afe819dc7412180f9f817043f27441de3498e4d0479R462-R470): Added a new `RuleFixer` type to handle rule fixes more flexibly.
* [`packages/core/src/types.ts`](diffhunk://#diff-4c2458380e50c967c70d7afe819dc7412180f9f817043f27441de3498e4d0479L479-R502): Updated the `fix` and `suggest` properties in the `ViolationReportBase` interface to use the new `RuleFixer` type and allow `null` or `undefined` values.

New test cases:

* [`packages/core/tests/types/types.test.ts`](diffhunk://#diff-c0892be62048a8f5638ea00563605a436c3fbe6f3bff221b9978e2239434c991R260): Added a new test case for the `suggest` property to ensure it can be `undefined`.
* [`packages/core/tests/types/types.test.ts`](diffhunk://#diff-c0892be62048a8f5638ea00563605a436c3fbe6f3bff221b9978e2239434c991R276-R284): Added a new test case to check the handling of `fix` and `suggest` properties when they are `null`.

#### Related Issues

Refs https://github.com/eslint/eslint/issues/19441

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
