### PR TITLE
feat: normalize patterns to handle "./" prefix in files and ignores

### DIFF
--- a/packages/config-array/src/config-array.js
+++ b/packages/config-array/src/config-array.js
@@ -281,6 +281,10 @@ function needsPatternNormalization(pattern) {
  * @param {Object} config The config object to normalize patterns in.
  */
 function normalizeConfigPatterns(config) {
+	if (!config) {
+		return config;
+	}
+
 	let needsNormalization = false;
 
 	if (Array.isArray(config.files)) {

--- a/packages/config-array/src/config-array.js
+++ b/packages/config-array/src/config-array.js
@@ -279,6 +279,7 @@ function needsPatternNormalization(pattern) {
 /**
  * Normalizes `files` and `ignores` patterns in a config by removing "./" prefixes.
  * @param {Object} config The config object to normalize patterns in.
+ * @returns {Object} The normalized config object.
  */
 function normalizeConfigPatterns(config) {
 	if (!config) {

--- a/packages/config-array/src/config-array.js
+++ b/packages/config-array/src/config-array.js
@@ -265,7 +265,6 @@ function normalizePattern(pattern) {
 
 /**
  * Checks if a given pattern requires normalization.
- *
  * @param {any} pattern The pattern to check.
  * @returns {boolean} True if the pattern needs normalization, false otherwise.
  *

--- a/packages/config-array/tests/config-array.test.js
+++ b/packages/config-array/tests/config-array.test.js
@@ -426,7 +426,7 @@ describe("ConfigArray", () => {
 
 			assert.throws(() => {
 				configs.normalizeSync();
-			}, "Config Error: Config (unnamed): Unexpected non-object config.");
+			}, /ConfigError: Config \(unnamed\): Unexpected non-object config./u);
 		});
 
 		it("should throw an error when base config name is not a string", async () => {
@@ -444,7 +444,7 @@ describe("ConfigArray", () => {
 
 			assert.throws(() => {
 				configs.getConfig("foo.js");
-			}, 'Config Error: Config (unnamed): Key "name": Property must be a string.');
+			}, /ConfigError: Config \(unnamed\): Key "name": Property must be a string./u);
 		});
 
 		it("should throw an error when additional config name is not a string", async () => {
@@ -458,7 +458,7 @@ describe("ConfigArray", () => {
 
 			assert.throws(() => {
 				configs.getConfig("foo.js");
-			}, 'Config Error: Config (unnamed): Key "name": Property must be a string.');
+			}, /ConfigError: Config \(unnamed\): Key "name": Property must be a string./u);
 		});
 
 		it("should throw an error when base config is undefined", () => {
@@ -466,7 +466,7 @@ describe("ConfigArray", () => {
 
 			assert.throws(() => {
 				configs.normalizeSync();
-			}, "ConfigError: Config (unnamed): Unexpected undefined config.");
+			}, /ConfigError: Config \(unnamed\): Unexpected undefined config./u);
 		});
 
 		it("should throw an error when base config is null", () => {
@@ -474,7 +474,7 @@ describe("ConfigArray", () => {
 
 			assert.throws(() => {
 				configs.normalizeSync();
-			}, "Config Error: Config (unnamed): Unexpected null config.");
+			}, /ConfigError: Config \(unnamed\): Unexpected null config./u);
 		});
 
 		it("should throw an error when additional config is undefined", () => {
@@ -483,7 +483,7 @@ describe("ConfigArray", () => {
 
 			assert.throws(() => {
 				configs.normalizeSync();
-			}, "Config Error: Config (unnamed): Unexpected undefined config.");
+			}, /ConfigError: Config \(unnamed\): Unexpected undefined config./u);
 		});
 
 		it("should throw an error when additional config is null", () => {
@@ -492,7 +492,7 @@ describe("ConfigArray", () => {
 
 			assert.throws(() => {
 				configs.normalizeSync();
-			}, "Config Error: Config (unnamed): Unexpected null config.");
+			}, /ConfigError: Config \(unnamed\): Unexpected null config./u);
 		});
 
 		it("should throw an error when basePath is a relative path", () => {

--- a/packages/config-array/tests/config-array.test.js
+++ b/packages/config-array/tests/config-array.test.js
@@ -1371,6 +1371,50 @@ describe("ConfigArray", () => {
 						"error",
 					);
 				});
+
+				it("should match nested `files` patterns with './' prefix", () => {
+					configs = new ConfigArray(
+						[
+							{
+								files: [["./src/*.js"]],
+								defs: { severity: "error" },
+							},
+						],
+						{
+							basePath,
+							schema,
+						},
+					);
+
+					configs.normalizeSync();
+
+					assert.strictEqual(
+						configs.getConfig("src/foo.js").defs.severity,
+						"error",
+					);
+				});
+
+				it("should match patterns with './' prefix in `files` patterns using normalize()", async () => {
+					configs = new ConfigArray(
+						[
+							{
+								files: ["./src/*.js"],
+								defs: { severity: "error" },
+							},
+						],
+						{
+							basePath,
+							schema,
+						},
+					);
+
+					await configs.normalize();
+
+					assert.strictEqual(
+						configs.getConfig("src/foo.js").defs.severity,
+						"error",
+					);
+				});
 			});
 		});
 

--- a/packages/config-array/tests/config-array.test.js
+++ b/packages/config-array/tests/config-array.test.js
@@ -1229,6 +1229,149 @@ describe("ConfigArray", () => {
 					assert.strictEqual(config2.defs.severity, "error");
 				});
 			});
+
+			// https://github.com/eslint/eslint/issues/18757
+			describe("patterns with './' prefix", () => {
+				it("should match patterns with './' prefix in `files` patterns", () => {
+					configs = new ConfigArray(
+						[
+							{
+								files: ["./src/*.js"],
+								defs: { severity: "error" },
+							},
+						],
+						{
+							basePath,
+							schema,
+						},
+					);
+
+					configs.normalizeSync();
+
+					assert.strictEqual(
+						configs.getConfig("src/foo.js").defs.severity,
+						"error",
+					);
+				});
+
+				it("should match patterns with './' prefix in `ignores` patterns", () => {
+					configs = new ConfigArray(
+						[
+							{
+								files: ["**/*.js"],
+								ignores: ["./src/*.js"],
+								defs: { severity: "error" },
+							},
+						],
+						{
+							basePath,
+							schema,
+						},
+					);
+
+					configs.normalizeSync();
+
+					assert.strictEqual(
+						configs.getConfig("src/foo.js"),
+						undefined,
+					);
+				});
+
+				it("should match patterns with './' prefix in global `ignores` patterns", () => {
+					configs = new ConfigArray(
+						[
+							{
+								files: ["**/*.js"],
+								defs: { severity: "error" },
+							},
+							{
+								ignores: ["./src/*.js"],
+							},
+						],
+						{
+							basePath,
+							schema,
+						},
+					);
+
+					configs.normalizeSync();
+
+					assert.strictEqual(
+						configs.getConfig("src/foo.js"),
+						undefined,
+					);
+				});
+
+				it("should match negated `files` patterns with './' prefix", () => {
+					configs = new ConfigArray(
+						[
+							{
+								files: ["!./src/*.js"],
+								defs: { severity: "error" },
+							},
+						],
+						{
+							basePath,
+							schema,
+						},
+					);
+
+					configs.normalizeSync();
+
+					assert.strictEqual(
+						configs.getConfig("src/foo.js"),
+						undefined,
+					);
+				});
+
+				it("should match negated `ignores` patterns with './' prefix", () => {
+					configs = new ConfigArray(
+						[
+							{
+								files: ["**/*.js"],
+								ignores: ["**/*.js", "!./src/foo.js"],
+								defs: { severity: "error" },
+							},
+						],
+						{
+							basePath,
+							schema,
+						},
+					);
+
+					configs.normalizeSync();
+
+					assert.strictEqual(
+						configs.getConfig("src/foo.js").defs.severity,
+						"error",
+					);
+				});
+
+				it("should match negated global `ignores` patterns with './' prefix", () => {
+					configs = new ConfigArray(
+						[
+							{
+								files: ["**/*.js"],
+								defs: { severity: "error" },
+							},
+							{
+								ignores: ["**/*.js", "!./src/*.js"],
+							},
+						],
+						{
+							basePath,
+							schema,
+						},
+					);
+
+					configs.normalizeSync();
+
+					assert.strictEqual(
+						configs.getConfig("src/foo.js").defs.severity,
+						"error",
+					);
+				});
+			});
 		});
 
 		describe("getConfigStatus()", () => {

--- a/packages/config-array/tests/config-array.test.js
+++ b/packages/config-array/tests/config-array.test.js
@@ -526,6 +526,36 @@ describe("ConfigArray", () => {
 		});
 	});
 
+	describe("Config Pattern Normalization", () => {
+		it("should create a new object when normalizing config patterns with ./", () => {
+			const config = {
+				files: ["./foo.js"],
+			};
+
+			configs = new ConfigArray([config], {
+				basePath,
+			});
+
+			configs.normalizeSync();
+
+			assert.notStrictEqual(configs[0], config);
+		});
+
+		it("should create a new object when normalizing config patterns with !./", async () => {
+			const config = {
+				ignores: ["!./foo.js"],
+			};
+
+			configs = new ConfigArray([config], {
+				basePath,
+			});
+
+			await configs.normalize();
+
+			assert.notStrictEqual(configs[0], config);
+		});
+	});
+
 	describe("ConfigArray members", () => {
 		beforeEach(() => {
 			configs = createConfigArray();


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Addresses issue where patterns starting with "./" were not correctly matched in `files` and `ignores`.

#### What changes did you make? (Give an overview)

Strip "./" from the start of strings in `files` and `ignores` so that they match as expected.

#### Related Issues

https://github.com/eslint/eslint/issues/18757

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
