### PR TITLE
feat: Use defineConfig() and globalIgnores() helpers

### DIFF
--- a/packages/migrate-config/tests/fixtures/basic-eslintrc/expected.cjs
+++ b/packages/migrate-config/tests/fixtures/basic-eslintrc/expected.cjs
@@ -1,4 +1,9 @@
 const {
+    defineConfig,
+    globalIgnores,
+} = require("eslint/config");
+
+const {
     fixupConfigRules,
     fixupPluginRules,
 } = require("@eslint/compat");
@@ -23,9 +28,9 @@ const compat = new FlatCompat({
     allConfig: js.configs.all
 });
 
-module.exports = [{
-    ignores: ["*/a.js", "dir/**/*", "**/dir/"],
-}, ...fixupConfigRules(compat.extends("eslint:recommended", "plugin:import/errors")), {
+module.exports = defineConfig([globalIgnores(["*/a.js", "dir/**/*", "**/dir/"]), {
+    extends: fixupConfigRules(compat.extends("eslint:recommended", "plugin:import/errors")),
+
     plugins: {
         prettier,
         import: fixupPluginRules(_import),
@@ -51,13 +56,10 @@ module.exports = [{
         quotes: ["error"],
         "no-console": ["warn"],
     },
-}, ...compat.extends("plugin:@typescript-eslint/recommended").map(config => ({
-    ...config,
+}, {
     files: ["**/*.ts"],
     ignores: ["**/*.d.ts"],
-})), {
-    files: ["**/*.ts"],
-    ignores: ["**/*.d.ts"],
+    extends: compat.extends("plugin:@typescript-eslint/recommended"),
 
     plugins: {
         "@typescript-eslint": typescriptEslint,
@@ -71,4 +73,4 @@ module.exports = [{
         "@typescript-eslint/no-explicit-any": ["error"],
         "@typescript-eslint/no-unused-vars": ["error"],
     },
-}];
+}]);

--- a/packages/migrate-config/tests/fixtures/basic-eslintrc/expected.mjs
+++ b/packages/migrate-config/tests/fixtures/basic-eslintrc/expected.mjs
@@ -1,3 +1,4 @@
+import { defineConfig, globalIgnores } from "eslint/config";
 import { fixupConfigRules, fixupPluginRules } from "@eslint/compat";
 import prettier from "eslint-plugin-prettier";
 import _import from "eslint-plugin-import";
@@ -20,9 +21,9 @@ const compat = new FlatCompat({
     allConfig: js.configs.all
 });
 
-export default [{
-    ignores: ["*/a.js", "dir/**/*", "**/dir/"],
-}, ...fixupConfigRules(compat.extends("eslint:recommended", "plugin:import/errors")), {
+export default defineConfig([globalIgnores(["*/a.js", "dir/**/*", "**/dir/"]), {
+    extends: fixupConfigRules(compat.extends("eslint:recommended", "plugin:import/errors")),
+
     plugins: {
         prettier,
         import: fixupPluginRules(_import),
@@ -48,13 +49,10 @@ export default [{
         quotes: ["error"],
         "no-console": ["warn"],
     },
-}, ...compat.extends("plugin:@typescript-eslint/recommended").map(config => ({
-    ...config,
+}, {
     files: ["**/*.ts"],
     ignores: ["**/*.d.ts"],
-})), {
-    files: ["**/*.ts"],
-    ignores: ["**/*.d.ts"],
+    extends: compat.extends("plugin:@typescript-eslint/recommended"),
 
     plugins: {
         "@typescript-eslint": typescriptEslint,
@@ -68,4 +66,4 @@ export default [{
         "@typescript-eslint/no-explicit-any": ["error"],
         "@typescript-eslint/no-unused-vars": ["error"],
     },
-}];
+}]);

--- a/packages/migrate-config/tests/fixtures/gitignore-complex/expected.cjs
+++ b/packages/migrate-config/tests/fixtures/gitignore-complex/expected.cjs
@@ -1,3 +1,8 @@
+const {
+    defineConfig,
+    globalIgnores,
+} = require("eslint/config");
+
 const js = require("@eslint/js");
 
 const {
@@ -16,10 +21,10 @@ const compat = new FlatCompat({
 });
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
-module.exports = [{
-    ignores: ["**/baz"],
-}, includeIgnoreFile(gitignorePath), ...compat.extends("eslint:recommended"), {
+module.exports = defineConfig([globalIgnores(["**/baz"]), includeIgnoreFile(gitignorePath), {
+    extends: compat.extends("eslint:recommended"),
+
     rules: {
         "no-console": "off",
     },
-}];
+}]);

--- a/packages/migrate-config/tests/fixtures/gitignore-complex/expected.mjs
+++ b/packages/migrate-config/tests/fixtures/gitignore-complex/expected.mjs
@@ -1,3 +1,4 @@
+import { defineConfig, globalIgnores } from "eslint/config";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import js from "@eslint/js";
@@ -13,10 +14,10 @@ const compat = new FlatCompat({
 });
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
-export default [{
-    ignores: ["**/baz"],
-}, includeIgnoreFile(gitignorePath), ...compat.extends("eslint:recommended"), {
+export default defineConfig([globalIgnores(["**/baz"]), includeIgnoreFile(gitignorePath), {
+    extends: compat.extends("eslint:recommended"),
+
     rules: {
         "no-console": "off",
     },
-}];
+}]);

--- a/packages/migrate-config/tests/fixtures/gitignore-simple/expected.cjs
+++ b/packages/migrate-config/tests/fixtures/gitignore-simple/expected.cjs
@@ -1,12 +1,16 @@
 const {
+    defineConfig,
+} = require("eslint/config");
+
+const {
     includeIgnoreFile,
 } = require("@eslint/compat");
 
 const path = require("node:path");
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
-module.exports = [includeIgnoreFile(gitignorePath), {
+module.exports = defineConfig([includeIgnoreFile(gitignorePath), {
     rules: {
         "no-console": "off",
     },
-}];
+}]);

--- a/packages/migrate-config/tests/fixtures/gitignore-simple/expected.mjs
+++ b/packages/migrate-config/tests/fixtures/gitignore-simple/expected.mjs
@@ -1,3 +1,4 @@
+import { defineConfig } from "eslint/config";
 import { includeIgnoreFile } from "@eslint/compat";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -6,8 +7,8 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const gitignorePath = path.resolve(__dirname, ".gitignore");
 
-export default [includeIgnoreFile(gitignorePath), {
+export default defineConfig([includeIgnoreFile(gitignorePath), {
     rules: {
         "no-console": "off",
     },
-}];
+}]);

--- a/packages/migrate-config/tests/fixtures/import-duplicate/expected.cjs
+++ b/packages/migrate-config/tests/fixtures/import-duplicate/expected.cjs
@@ -1,3 +1,7 @@
+const {
+    defineConfig,
+} = require("eslint/config");
+
 const _import = require("eslint-plugin-import");
 
 const {
@@ -6,7 +10,7 @@ const {
 
 const reactHooks = require("eslint-plugin-react-hooks");
 
-module.exports = [{
+module.exports = defineConfig([{
     plugins: {
         import: fixupPluginRules(_import),
     },
@@ -14,4 +18,4 @@ module.exports = [{
     plugins: {
         "react-hooks": fixupPluginRules(reactHooks),
     },
-}];
+}]);

--- a/packages/migrate-config/tests/fixtures/import-duplicate/expected.mjs
+++ b/packages/migrate-config/tests/fixtures/import-duplicate/expected.mjs
@@ -1,8 +1,9 @@
+import { defineConfig } from "eslint/config";
 import _import from "eslint-plugin-import";
 import { fixupPluginRules } from "@eslint/compat";
 import reactHooks from "eslint-plugin-react-hooks";
 
-export default [{
+export default defineConfig([{
     plugins: {
         import: fixupPluginRules(_import),
     },
@@ -10,4 +11,4 @@ export default [{
     plugins: {
         "react-hooks": fixupPluginRules(reactHooks),
     },
-}];
+}]);

--- a/packages/migrate-config/tests/fixtures/no-globals-for-env/expected.cjs
+++ b/packages/migrate-config/tests/fixtures/no-globals-for-env/expected.cjs
@@ -1,4 +1,8 @@
 const {
+    defineConfig,
+} = require("eslint/config");
+
+const {
     fixupConfigRules,
     fixupPluginRules,
 } = require("@eslint/compat");
@@ -22,53 +26,47 @@ const compat = new FlatCompat({
     allConfig: js.configs.all
 });
 
-module.exports = [
-    ...fixupConfigRules(compat.extends("eslint:recommended", "plugin:import/errors")),
-    {
-        plugins: {
-            prettier,
-            import: fixupPluginRules(_import),
-            node,
-            promise,
-            standard,
-            "@typescript-eslint": typescriptEslint,
-        },
+module.exports = defineConfig([{
+    extends: fixupConfigRules(compat.extends("eslint:recommended", "plugin:import/errors")),
 
-        languageOptions: {
-            globals: {
-                ...node.environments.base.globals,
-            },
-
-            ecmaVersion: 2018,
-            sourceType: "script",
-        },
-
-        rules: {
-            semi: ["error"],
-            quotes: ["error"],
-            "no-console": ["warn"],
-        },
+    plugins: {
+        prettier,
+        import: fixupPluginRules(_import),
+        node,
+        promise,
+        standard,
+        "@typescript-eslint": typescriptEslint,
     },
-    ...compat.extends("plugin:@typescript-eslint/recommended").map(config => ({
-        ...config,
-        files: ["**/*.ts"],
-        ignores: ["**/*.d.ts"],
-    })),
-    {
-        files: ["**/*.ts"],
-        ignores: ["**/*.d.ts"],
 
-        plugins: {
-            "@typescript-eslint": typescriptEslint,
+    languageOptions: {
+        globals: {
+            ...node.environments.base.globals,
         },
 
-        languageOptions: {
-            parser: tsParser,
-        },
-
-        rules: {
-            "@typescript-eslint/no-explicit-any": ["error"],
-            "@typescript-eslint/no-unused-vars": ["error"],
-        },
+        ecmaVersion: 2018,
+        sourceType: "script",
     },
-];
+
+    rules: {
+        semi: ["error"],
+        quotes: ["error"],
+        "no-console": ["warn"],
+    },
+}, {
+    files: ["**/*.ts"],
+    ignores: ["**/*.d.ts"],
+    extends: compat.extends("plugin:@typescript-eslint/recommended"),
+
+    plugins: {
+        "@typescript-eslint": typescriptEslint,
+    },
+
+    languageOptions: {
+        parser: tsParser,
+    },
+
+    rules: {
+        "@typescript-eslint/no-explicit-any": ["error"],
+        "@typescript-eslint/no-unused-vars": ["error"],
+    },
+}]);

--- a/packages/migrate-config/tests/fixtures/no-globals-for-env/expected.mjs
+++ b/packages/migrate-config/tests/fixtures/no-globals-for-env/expected.mjs
@@ -1,3 +1,4 @@
+import { defineConfig } from "eslint/config";
 import { fixupConfigRules, fixupPluginRules } from "@eslint/compat";
 import prettier from "eslint-plugin-prettier";
 import _import from "eslint-plugin-import";
@@ -19,53 +20,47 @@ const compat = new FlatCompat({
     allConfig: js.configs.all
 });
 
-export default [
-    ...fixupConfigRules(compat.extends("eslint:recommended", "plugin:import/errors")),
-    {
-        plugins: {
-            prettier,
-            import: fixupPluginRules(_import),
-            node,
-            promise,
-            standard,
-            "@typescript-eslint": typescriptEslint,
-        },
+export default defineConfig([{
+    extends: fixupConfigRules(compat.extends("eslint:recommended", "plugin:import/errors")),
 
-        languageOptions: {
-            globals: {
-                ...node.environments.base.globals,
-            },
-
-            ecmaVersion: 2018,
-            sourceType: "script",
-        },
-
-        rules: {
-            semi: ["error"],
-            quotes: ["error"],
-            "no-console": ["warn"],
-        },
+    plugins: {
+        prettier,
+        import: fixupPluginRules(_import),
+        node,
+        promise,
+        standard,
+        "@typescript-eslint": typescriptEslint,
     },
-    ...compat.extends("plugin:@typescript-eslint/recommended").map(config => ({
-        ...config,
-        files: ["**/*.ts"],
-        ignores: ["**/*.d.ts"],
-    })),
-    {
-        files: ["**/*.ts"],
-        ignores: ["**/*.d.ts"],
 
-        plugins: {
-            "@typescript-eslint": typescriptEslint,
+    languageOptions: {
+        globals: {
+            ...node.environments.base.globals,
         },
 
-        languageOptions: {
-            parser: tsParser,
-        },
-
-        rules: {
-            "@typescript-eslint/no-explicit-any": ["error"],
-            "@typescript-eslint/no-unused-vars": ["error"],
-        },
+        ecmaVersion: 2018,
+        sourceType: "script",
     },
-];
+
+    rules: {
+        semi: ["error"],
+        quotes: ["error"],
+        "no-console": ["warn"],
+    },
+}, {
+    files: ["**/*.ts"],
+    ignores: ["**/*.d.ts"],
+    extends: compat.extends("plugin:@typescript-eslint/recommended"),
+
+    plugins: {
+        "@typescript-eslint": typescriptEslint,
+    },
+
+    languageOptions: {
+        parser: tsParser,
+    },
+
+    rules: {
+        "@typescript-eslint/no-explicit-any": ["error"],
+        "@typescript-eslint/no-unused-vars": ["error"],
+    },
+}]);

--- a/packages/migrate-config/tests/fixtures/overrides-extends/expected.cjs
+++ b/packages/migrate-config/tests/fixtures/overrides-extends/expected.cjs
@@ -1,3 +1,7 @@
+const {
+    defineConfig,
+} = require("eslint/config");
+
 const js = require("@eslint/js");
 
 const {
@@ -10,14 +14,14 @@ const compat = new FlatCompat({
     allConfig: js.configs.all
 });
 
-module.exports = [...compat.extends("airbnb").map(config => ({
-    ...config,
+module.exports = defineConfig([{
     files: ["src/app/**"],
     ignores: ["**/*.test.js"],
-})), ...compat.extends("airbnb-base").map(config => ({
-    ...config,
+    extends: compat.extends("airbnb"),
+}, {
     files: ["src/app/**/*.test.js"],
-})), ...compat.extends("airbnb-base").map(config => ({
-    ...config,
+    extends: compat.extends("airbnb-base"),
+}, {
     ignores: ["src/app/**/*.spec.js"],
-}))];
+    extends: compat.extends("airbnb-base"),
+}]);

--- a/packages/migrate-config/tests/fixtures/overrides-extends/expected.mjs
+++ b/packages/migrate-config/tests/fixtures/overrides-extends/expected.mjs
@@ -1,3 +1,4 @@
+import { defineConfig } from "eslint/config";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import js from "@eslint/js";
@@ -11,14 +12,14 @@ const compat = new FlatCompat({
     allConfig: js.configs.all
 });
 
-export default [...compat.extends("airbnb").map(config => ({
-    ...config,
+export default defineConfig([{
     files: ["src/app/**"],
     ignores: ["**/*.test.js"],
-})), ...compat.extends("airbnb-base").map(config => ({
-    ...config,
+    extends: compat.extends("airbnb"),
+}, {
     files: ["src/app/**/*.test.js"],
-})), ...compat.extends("airbnb-base").map(config => ({
-    ...config,
+    extends: compat.extends("airbnb-base"),
+}, {
     ignores: ["src/app/**/*.spec.js"],
-}))];
+    extends: compat.extends("airbnb-base"),
+}]);

--- a/packages/migrate-config/tests/fixtures/plugins-dedupe/expected.cjs
+++ b/packages/migrate-config/tests/fixtures/plugins-dedupe/expected.cjs
@@ -1,4 +1,8 @@
 const {
+    defineConfig,
+} = require("eslint/config");
+
+const {
     fixupConfigRules,
     fixupPluginRules,
 } = require("@eslint/compat");
@@ -17,12 +21,11 @@ const compat = new FlatCompat({
     allConfig: js.configs.all
 });
 
-module.exports = [
-    ...fixupConfigRules(compat.extends("plugin:import/errors", "plugin:n/recommended")),
-    {
-        plugins: {
-            import: fixupPluginRules(_import),
-            n: fixupPluginRules(n),
-        },
+module.exports = defineConfig([{
+    extends: fixupConfigRules(compat.extends("plugin:import/errors", "plugin:n/recommended")),
+
+    plugins: {
+        import: fixupPluginRules(_import),
+        n: fixupPluginRules(n),
     },
-];
+}]);

--- a/packages/migrate-config/tests/fixtures/plugins-dedupe/expected.mjs
+++ b/packages/migrate-config/tests/fixtures/plugins-dedupe/expected.mjs
@@ -1,3 +1,4 @@
+import { defineConfig } from "eslint/config";
 import { fixupConfigRules, fixupPluginRules } from "@eslint/compat";
 import _import from "eslint-plugin-import";
 import n from "eslint-plugin-n";
@@ -14,12 +15,11 @@ const compat = new FlatCompat({
     allConfig: js.configs.all
 });
 
-export default [
-    ...fixupConfigRules(compat.extends("plugin:import/errors", "plugin:n/recommended")),
-    {
-        plugins: {
-            import: fixupPluginRules(_import),
-            n: fixupPluginRules(n),
-        },
+export default defineConfig([{
+    extends: fixupConfigRules(compat.extends("plugin:import/errors", "plugin:n/recommended")),
+
+    plugins: {
+        import: fixupPluginRules(_import),
+        n: fixupPluginRules(n),
     },
-];
+}]);

--- a/packages/migrate-config/tests/fixtures/prisma/expected.cjs
+++ b/packages/migrate-config/tests/fixtures/prisma/expected.cjs
@@ -1,3 +1,8 @@
+const {
+    defineConfig,
+    globalIgnores,
+} = require("eslint/config");
+
 const typescriptEslint = require("@typescript-eslint/eslint-plugin");
 const jest = require("eslint-plugin-jest");
 const simpleImportSort = require("eslint-plugin-simple-import-sort");
@@ -22,37 +27,37 @@ const compat = new FlatCompat({
     allConfig: js.configs.all
 });
 
-module.exports = [{
-    ignores: [
-        ".github/renovate.json",
-        "**/dist/",
-        "**/esm/",
-        "**/build/",
-        "**/fixtures/",
-        "**/byline.ts",
-        "**/prism.ts",
-        "**/charm.ts",
-        "**/pnpm-lock.yaml",
-        "**/generated-dmmf.ts",
-        "packages/client/generator-build/",
-        "packages/client/declaration/",
-        "packages/client/runtime/",
-        "packages/client/src/__tests__/types/",
-        "packages/client/scripts/default-index.js",
-        "packages/cli/prisma-client/",
-        "packages/cli/install/",
-        "packages/cli/preinstall/",
-        "packages/cli/**/tmp-*",
-        "**/sandbox/",
-    ],
-}, ...compat.extends(
-    "eslint:recommended",
-    "plugin:@typescript-eslint/eslint-recommended",
-    "plugin:@typescript-eslint/recommended",
-    "plugin:@typescript-eslint/recommended-requiring-type-checking",
-    "plugin:prettier/recommended",
-    "plugin:jest/recommended",
-), {
+module.exports = defineConfig([globalIgnores([
+    ".github/renovate.json",
+    "**/dist/",
+    "**/esm/",
+    "**/build/",
+    "**/fixtures/",
+    "**/byline.ts",
+    "**/prism.ts",
+    "**/charm.ts",
+    "**/pnpm-lock.yaml",
+    "**/generated-dmmf.ts",
+    "packages/client/generator-build/",
+    "packages/client/declaration/",
+    "packages/client/runtime/",
+    "packages/client/src/__tests__/types/",
+    "packages/client/scripts/default-index.js",
+    "packages/cli/prisma-client/",
+    "packages/cli/install/",
+    "packages/cli/preinstall/",
+    "packages/cli/**/tmp-*",
+    "**/sandbox/",
+]), {
+    extends: compat.extends(
+        "eslint:recommended",
+        "plugin:@typescript-eslint/eslint-recommended",
+        "plugin:@typescript-eslint/recommended",
+        "plugin:@typescript-eslint/recommended-requiring-type-checking",
+        "plugin:prettier/recommended",
+        "plugin:jest/recommended",
+    ),
+
     plugins: {
         "@typescript-eslint": typescriptEslint,
         jest,
@@ -147,4 +152,4 @@ module.exports = [{
     rules: {
         "local-rules/valid-exported-types-index": "error",
     },
-}];
+}]);

--- a/packages/migrate-config/tests/fixtures/prisma/expected.mjs
+++ b/packages/migrate-config/tests/fixtures/prisma/expected.mjs
@@ -1,3 +1,4 @@
+import { defineConfig, globalIgnores } from "eslint/config";
 import typescriptEslint from "@typescript-eslint/eslint-plugin";
 import jest from "eslint-plugin-jest";
 import simpleImportSort from "eslint-plugin-simple-import-sort";
@@ -19,37 +20,37 @@ const compat = new FlatCompat({
     allConfig: js.configs.all
 });
 
-export default [{
-    ignores: [
-        ".github/renovate.json",
-        "**/dist/",
-        "**/esm/",
-        "**/build/",
-        "**/fixtures/",
-        "**/byline.ts",
-        "**/prism.ts",
-        "**/charm.ts",
-        "**/pnpm-lock.yaml",
-        "**/generated-dmmf.ts",
-        "packages/client/generator-build/",
-        "packages/client/declaration/",
-        "packages/client/runtime/",
-        "packages/client/src/__tests__/types/",
-        "packages/client/scripts/default-index.js",
-        "packages/cli/prisma-client/",
-        "packages/cli/install/",
-        "packages/cli/preinstall/",
-        "packages/cli/**/tmp-*",
-        "**/sandbox/",
-    ],
-}, ...compat.extends(
-    "eslint:recommended",
-    "plugin:@typescript-eslint/eslint-recommended",
-    "plugin:@typescript-eslint/recommended",
-    "plugin:@typescript-eslint/recommended-requiring-type-checking",
-    "plugin:prettier/recommended",
-    "plugin:jest/recommended",
-), {
+export default defineConfig([globalIgnores([
+    ".github/renovate.json",
+    "**/dist/",
+    "**/esm/",
+    "**/build/",
+    "**/fixtures/",
+    "**/byline.ts",
+    "**/prism.ts",
+    "**/charm.ts",
+    "**/pnpm-lock.yaml",
+    "**/generated-dmmf.ts",
+    "packages/client/generator-build/",
+    "packages/client/declaration/",
+    "packages/client/runtime/",
+    "packages/client/src/__tests__/types/",
+    "packages/client/scripts/default-index.js",
+    "packages/cli/prisma-client/",
+    "packages/cli/install/",
+    "packages/cli/preinstall/",
+    "packages/cli/**/tmp-*",
+    "**/sandbox/",
+]), {
+    extends: compat.extends(
+        "eslint:recommended",
+        "plugin:@typescript-eslint/eslint-recommended",
+        "plugin:@typescript-eslint/recommended",
+        "plugin:@typescript-eslint/recommended-requiring-type-checking",
+        "plugin:prettier/recommended",
+        "plugin:jest/recommended",
+    ),
+
     plugins: {
         "@typescript-eslint": typescriptEslint,
         jest,
@@ -144,4 +145,4 @@ export default [{
     rules: {
         "local-rules/valid-exported-types-index": "error",
     },
-}];
+}]);

--- a/packages/migrate-config/tests/fixtures/release-it/expected.cjs
+++ b/packages/migrate-config/tests/fixtures/release-it/expected.cjs
@@ -1,4 +1,8 @@
 const {
+    defineConfig,
+} = require("eslint/config");
+
+const {
     fixupConfigRules,
     fixupPluginRules,
 } = require("@eslint/compat");
@@ -18,37 +22,36 @@ const compat = new FlatCompat({
     allConfig: js.configs.all
 });
 
-module.exports = [
-    ...fixupConfigRules(compat.extends("eslint:recommended", "plugin:ava/recommended", "prettier")),
-    {
-        plugins: {
-            prettier,
-            import: fixupPluginRules(_import),
-        },
+module.exports = defineConfig([{
+    extends: fixupConfigRules(compat.extends("eslint:recommended", "plugin:ava/recommended", "prettier")),
 
-        languageOptions: {
-            globals: {
-                ...globals.node,
-            },
-
-            ecmaVersion: 2020,
-            sourceType: "module",
-        },
-
-        rules: {
-            "prettier/prettier": 2,
-            "ava/no-ignored-test-files": 0,
-            "ava/no-import-test-files": 0,
-
-            "import/no-unresolved": [2, {
-                ignore: ["ava", "got"],
-            }],
-
-            "import/no-unused-modules": 2,
-
-            "import/order": [2, {
-                "newlines-between": "never",
-            }],
-        },
+    plugins: {
+        prettier,
+        import: fixupPluginRules(_import),
     },
-];
+
+    languageOptions: {
+        globals: {
+            ...globals.node,
+        },
+
+        ecmaVersion: 2020,
+        sourceType: "module",
+    },
+
+    rules: {
+        "prettier/prettier": 2,
+        "ava/no-ignored-test-files": 0,
+        "ava/no-import-test-files": 0,
+
+        "import/no-unresolved": [2, {
+            ignore: ["ava", "got"],
+        }],
+
+        "import/no-unused-modules": 2,
+
+        "import/order": [2, {
+            "newlines-between": "never",
+        }],
+    },
+}]);

--- a/packages/migrate-config/tests/fixtures/release-it/expected.mjs
+++ b/packages/migrate-config/tests/fixtures/release-it/expected.mjs
@@ -1,3 +1,4 @@
+import { defineConfig } from "eslint/config";
 import { fixupConfigRules, fixupPluginRules } from "@eslint/compat";
 import prettier from "eslint-plugin-prettier";
 import _import from "eslint-plugin-import";
@@ -15,37 +16,36 @@ const compat = new FlatCompat({
     allConfig: js.configs.all
 });
 
-export default [
-    ...fixupConfigRules(compat.extends("eslint:recommended", "plugin:ava/recommended", "prettier")),
-    {
-        plugins: {
-            prettier,
-            import: fixupPluginRules(_import),
-        },
+export default defineConfig([{
+    extends: fixupConfigRules(compat.extends("eslint:recommended", "plugin:ava/recommended", "prettier")),
 
-        languageOptions: {
-            globals: {
-                ...globals.node,
-            },
-
-            ecmaVersion: 2020,
-            sourceType: "module",
-        },
-
-        rules: {
-            "prettier/prettier": 2,
-            "ava/no-ignored-test-files": 0,
-            "ava/no-import-test-files": 0,
-
-            "import/no-unresolved": [2, {
-                ignore: ["ava", "got"],
-            }],
-
-            "import/no-unused-modules": 2,
-
-            "import/order": [2, {
-                "newlines-between": "never",
-            }],
-        },
+    plugins: {
+        prettier,
+        import: fixupPluginRules(_import),
     },
-];
+
+    languageOptions: {
+        globals: {
+            ...globals.node,
+        },
+
+        ecmaVersion: 2020,
+        sourceType: "module",
+    },
+
+    rules: {
+        "prettier/prettier": 2,
+        "ava/no-ignored-test-files": 0,
+        "ava/no-import-test-files": 0,
+
+        "import/no-unresolved": [2, {
+            ignore: ["ava", "got"],
+        }],
+
+        "import/no-unused-modules": 2,
+
+        "import/order": [2, {
+            "newlines-between": "never",
+        }],
+    },
+}]);

--- a/packages/migrate-config/tests/fixtures/reveal-md/expected.cjs
+++ b/packages/migrate-config/tests/fixtures/reveal-md/expected.cjs
@@ -1,3 +1,7 @@
+const {
+    defineConfig,
+} = require("eslint/config");
+
 const prettier = require("eslint-plugin-prettier");
 const _import = require("eslint-plugin-import");
 
@@ -18,7 +22,9 @@ const compat = new FlatCompat({
     allConfig: js.configs.all
 });
 
-module.exports = [...compat.extends("eslint:recommended", "prettier"), {
+module.exports = defineConfig([{
+    extends: compat.extends("eslint:recommended", "prettier"),
+
     plugins: {
         prettier,
         import: fixupPluginRules(_import),
@@ -41,4 +47,4 @@ module.exports = [...compat.extends("eslint:recommended", "prettier"), {
 
         "import/no-unresolved": 2,
     },
-}];
+}]);

--- a/packages/migrate-config/tests/fixtures/reveal-md/expected.mjs
+++ b/packages/migrate-config/tests/fixtures/reveal-md/expected.mjs
@@ -1,3 +1,4 @@
+import { defineConfig } from "eslint/config";
 import prettier from "eslint-plugin-prettier";
 import _import from "eslint-plugin-import";
 import { fixupPluginRules } from "@eslint/compat";
@@ -15,7 +16,9 @@ const compat = new FlatCompat({
     allConfig: js.configs.all
 });
 
-export default [...compat.extends("eslint:recommended", "prettier"), {
+export default defineConfig([{
+    extends: compat.extends("eslint:recommended", "prettier"),
+
     plugins: {
         prettier,
         import: fixupPluginRules(_import),
@@ -38,4 +41,4 @@ export default [...compat.extends("eslint:recommended", "prettier"), {
 
         "import/no-unresolved": 2,
     },
-}];
+}]);

--- a/packages/migrate-config/tests/fixtures/slash-package/expected.cjs
+++ b/packages/migrate-config/tests/fixtures/slash-package/expected.cjs
@@ -1,4 +1,8 @@
 const {
+    defineConfig,
+} = require("eslint/config");
+
+const {
     fixupConfigRules,
     fixupPluginRules,
 } = require("@eslint/compat");
@@ -17,14 +21,16 @@ const compat = new FlatCompat({
     allConfig: js.configs.all
 });
 
-module.exports = [...fixupConfigRules(compat.extends(
-    "react-app",
-    "prettier",
-    "plugin:jsx-a11y/recommended",
-    "plugin:@tanstack/eslint-plugin-query/recommended",
-)), {
+module.exports = defineConfig([{
+    extends: fixupConfigRules(compat.extends(
+        "react-app",
+        "prettier",
+        "plugin:jsx-a11y/recommended",
+        "plugin:@tanstack/eslint-plugin-query/recommended",
+    )),
+
     plugins: {
         "jsx-a11y": fixupPluginRules(jsxA11Y),
         "@tanstack/query": fixupPluginRules(tanstackQuery),
     },
-}];
+}]);

--- a/packages/migrate-config/tests/fixtures/slash-package/expected.mjs
+++ b/packages/migrate-config/tests/fixtures/slash-package/expected.mjs
@@ -1,3 +1,4 @@
+import { defineConfig } from "eslint/config";
 import { fixupConfigRules, fixupPluginRules } from "@eslint/compat";
 import jsxA11Y from "eslint-plugin-jsx-a11y";
 import tanstackQuery from "@tanstack/eslint-plugin-query";
@@ -14,14 +15,16 @@ const compat = new FlatCompat({
     allConfig: js.configs.all
 });
 
-export default [...fixupConfigRules(compat.extends(
-    "react-app",
-    "prettier",
-    "plugin:jsx-a11y/recommended",
-    "plugin:@tanstack/eslint-plugin-query/recommended",
-)), {
+export default defineConfig([{
+    extends: fixupConfigRules(compat.extends(
+        "react-app",
+        "prettier",
+        "plugin:jsx-a11y/recommended",
+        "plugin:@tanstack/eslint-plugin-query/recommended",
+    )),
+
     plugins: {
         "jsx-a11y": fixupPluginRules(jsxA11Y),
         "@tanstack/query": fixupPluginRules(tanstackQuery),
     },
-}];
+}]);


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Update `migrate-config` to produce configs that use `defineConfig()` and `globalIgnores()`

#### What changes did you make? (Give an overview)

* Updated the return type of `createGlobalIgnores` function to `CallExpression` and modified its implementation to use `globalIgnores` instead of an object expression. (`packages/migrate-config/src/migrate-config.js`) [[1]](diffhunk://#diff-783de1ed10b8bafd4690e61b68f4b159feb9b84efaf6b4d977c7b319cf2733ddL648-R648) [[2]](diffhunk://#diff-783de1ed10b8bafd4690e61b68f4b159feb9b84efaf6b4d977c7b319cf2733ddL659-R661)
* Modified `migrateConfigObject` to push properties directly instead of mapping them into an object. (`packages/migrate-config/src/migrate-config.js`)
* Ensured `defineConfig` is always used by adding it to the imports and creating a `defineConfigNode` for the configuration array. (`packages/migrate-config/src/migrate-config.js`) [[1]](diffhunk://#diff-783de1ed10b8bafd4690e61b68f4b159feb9b84efaf6b4d977c7b319cf2733ddR851-R855) [[2]](diffhunk://#diff-783de1ed10b8bafd4690e61b68f4b159feb9b84efaf6b4d977c7b319cf2733ddR923) [[3]](diffhunk://#diff-783de1ed10b8bafd4690e61b68f4b159feb9b84efaf6b4d977c7b319cf2733ddR986-R990) [[4]](diffhunk://#diff-783de1ed10b8bafd4690e61b68f4b159feb9b84efaf6b4d977c7b319cf2733ddL1020-R1006)
* Updated all test fixtures to reflect the new configuration format using `defineConfig` and `globalIgnores`. This includes changes in both CommonJS (`.cjs`) and ES Module (`.mjs`) formats. (`packages/migrate-config/tests/fixtures/basic-eslintrc/expected.cjs`, `packages/migrate-config/tests/fixtures/basic-eslintrc/expected.mjs`, `packages/migrate-config/tests/fixtures/gitignore-complex/expected.cjs`, `packages/migrate-config/tests/fixtures/gitignore-complex/expected.mjs`, `packages/migrate-config/tests/fixtures/gitignore-simple/expected.cjs`, `packages/migrate-config/tests/fixtures/gitignore-simple/expected.mjs`, `packages/migrate-config/tests/fixtures/import-duplicate/expected.cjs`, `packages/migrate-config/tests/fixtures/import-duplicate/expected.mjs`, `packages/migrate-config/tests/fixtures/no-globals-for-env/expected.cjs`, `packages/migrate-config/tests/fixtures/no-globals-for-env/expected.mjs`, `packages/migrate-config/tests/fixtures/overrides-extends/expected.cjs`) [[1]](diffhunk://#diff-a3b935bce7850d9f5c7e2dc1b147339b4f46be9fc7dd1762a694ec8435fcdf5dR1-R5) [[2]](diffhunk://#diff-a3b935bce7850d9f5c7e2dc1b147339b4f46be9fc7dd1762a694ec8435fcdf5dL26-R33) [[3]](diffhunk://#diff-a3b935bce7850d9f5c7e2dc1b147339b4f46be9fc7dd1762a694ec8435fcdf5dL54-R62) [[4]](diffhunk://#diff-a3b935bce7850d9f5c7e2dc1b147339b4f46be9fc7dd1762a694ec8435fcdf5dL74-R76) [[5]](diffhunk://#diff-f5eb9b00e20d083c504fd14148197df316921650058e989a6848a7de7ddb346cR1) [[6]](diffhunk://#diff-f5eb9b00e20d083c504fd14148197df316921650058e989a6848a7de7ddb346cL23-R26) [[7]](diffhunk://#diff-f5eb9b00e20d083c504fd14148197df316921650058e989a6848a7de7ddb346cL51-R55) [[8]](diffhunk://#diff-f5eb9b00e20d083c504fd14148197df316921650058e989a6848a7de7ddb346cL71-R69) [[9]](diffhunk://#diff-54535f602cfdeb528e79f2e5e972bbf17219c673fddd8e27e727653b2c52d649R1-R5) [[10]](diffhunk://#diff-54535f602cfdeb528e79f2e5e972bbf17219c673fddd8e27e727653b2c52d649L19-R30) [[11]](diffhunk://#diff-358123f68ddbf89d765cc71eb2e07039fab7ba42bff3e40e5d8485965c83346bR1) [[12]](diffhunk://#diff-358123f68ddbf89d765cc71eb2e07039fab7ba42bff3e40e5d8485965c83346bL16-R23) [[13]](diffhunk://#diff-087804c7f56140f4fd2f9717a9a7a33893a401624aa8b8a4e2379d3f0b1931dfR1-R16) [[14]](diffhunk://#diff-f87842b9da48475959764737d1b93c795c71ac5f1932d854f7099317cb7fd1f0R1) [[15]](diffhunk://#diff-f87842b9da48475959764737d1b93c795c71ac5f1932d854f7099317cb7fd1f0L9-R14) [[16]](diffhunk://#diff-8cf0212ca137146ee9998d2856ff7e9cffaeb33e42f60ae8771f977579c4679cR1-R4) [[17]](diffhunk://#diff-8cf0212ca137146ee9998d2856ff7e9cffaeb33e42f60ae8771f977579c4679cL9-R21) [[18]](diffhunk://#diff-5f802353d354b82ef4733d8195070390451d673c05b6fd1b16138c7c81bf0708R1-R14) [[19]](diffhunk://#diff-ff9d6184d276acf3dadb04b4a3fb071b6ae1045687444c19e95efce961e95592R1-R4) [[20]](diffhunk://#diff-ff9d6184d276acf3dadb04b4a3fb071b6ae1045687444c19e95efce961e95592L25-R31) [[21]](diffhunk://#diff-ff9d6184d276acf3dadb04b4a3fb071b6ae1045687444c19e95efce961e95592L51-R58) [[22]](diffhunk://#diff-ff9d6184d276acf3dadb04b4a3fb071b6ae1045687444c19e95efce961e95592L73-R72) [[23]](diffhunk://#diff-11b1b74ccf63bd393f3c0fce38c126c3fab8065668441c760c7e31df2f492ad4R1) [[24]](diffhunk://#diff-11b1b74ccf63bd393f3c0fce38c126c3fab8065668441c760c7e31df2f492ad4L22-R25) [[25]](diffhunk://#diff-11b1b74ccf63bd393f3c0fce38c126c3fab8065668441c760c7e31df2f492ad4L48-R52) [[26]](diffhunk://#diff-11b1b74ccf63bd393f3c0fce38c126c3fab8065668441c760c7e31df2f492ad4L70-R66) [[27]](diffhunk://#diff-e76b6902257065d64aad108b55836e3e7d155ffe8fc680d5a216b207cde150c9R1-R4)

#### Related Issues

fixes #163

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
