### PR TITLE
feat: Look up flat/ config alternatives in defineConfig

### DIFF
--- a/packages/config-helpers/tests/define-config.test.js
+++ b/packages/config-helpers/tests/define-config.test.js
@@ -788,7 +788,69 @@ describe("defineConfig()", () => {
 							"no-debugger": "error",
 						},
 					});
-				}, /Plugin config "test\/config1" is an eslintrc config and cannot be used in this context\./u);
+				}, /Plugin config "config1" in plugin "test" is an eslintrc config and cannot be used in this context\./u);
+			});
+
+			it("should use flat config when base config is legacy", () => {
+				const testPlugin = {
+					configs: {
+						recommended: {
+							env: { browser: true }, // legacy config
+							rules: { "no-console": "error" },
+						},
+						"flat/recommended": {
+							rules: { "no-console": "error" },
+						},
+					},
+				};
+
+				const config = defineConfig({
+					plugins: {
+						test: testPlugin,
+					},
+					extends: ["test/recommended"],
+					rules: {
+						"no-debugger": "error",
+					},
+				});
+
+				assert.deepStrictEqual(config, [
+					{
+						name: "UserConfig[0] > test/recommended",
+						rules: { "no-console": "error" },
+					},
+					{
+						plugins: { test: testPlugin },
+						rules: { "no-debugger": "error" },
+					},
+				]);
+			});
+
+			it("should throw error when both base and flat configs are legacy", () => {
+				const testPlugin = {
+					configs: {
+						recommended: {
+							env: { browser: true },
+							rules: { "no-console": "error" },
+						},
+						"flat/recommended": {
+							env: { browser: true },
+							rules: { "no-console": "error" },
+						},
+					},
+				};
+
+				assert.throws(() => {
+					defineConfig({
+						plugins: {
+							test: testPlugin,
+						},
+						extends: ["test/recommended"],
+						rules: {
+							"no-debugger": "error",
+						},
+					});
+				}, /Plugin config "recommended" in plugin "test" is an eslintrc config and cannot be used in this context\./u);
 			});
 		});
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Update `defineConfig()` to search for flat configs in plugins when a string is used in `extends`.

#### What changes did you make? (Give an overview)

- Updated `defineConfig()` so it `"plugin/config"` is eslintrc, then it search for `"plugin/flat/config"`. It throws an error if that config isn't found or is also eslintrc.
- Added tests.

#### Related Issues

Refs https://github.com/eslint/eslint/issues/19513

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
