### PR TITLE
test: fix error message checking

### DIFF
--- a/packages/config-array/tests/config-array.test.js
+++ b/packages/config-array/tests/config-array.test.js
@@ -310,17 +310,7 @@ describe("ConfigArray", () => {
 					basePath,
 				});
 
-				let actualError;
-				try {
-					await configArray.normalize();
-				} catch (error) {
-					actualError = error;
-				}
-				assert.throws(() => {
-					if (actualError) {
-						throw actualError;
-					}
-				}, expectedError.message);
+				await assert.rejects(configArray.normalize(), expectedError);
 			});
 
 			localIt(`${title} when calling normalizeSync()`, () => {
@@ -328,10 +318,7 @@ describe("ConfigArray", () => {
 					basePath,
 				});
 
-				assert.throws(
-					() => configArray.normalizeSync(),
-					expectedError.message,
-				);
+				assert.throws(() => configArray.normalizeSync(), expectedError);
 			});
 		}
 
@@ -374,7 +361,7 @@ describe("ConfigArray", () => {
 				},
 			],
 			expectedError:
-				'Config Error: Config (unnamed): Key "files": Items must be a string, a function, or an array of strings and functions.',
+				/ConfigError: Config \(unnamed\): Key "files": Items must be a string, a function, or an array of strings and functions\./u,
 		});
 
 		testValidationError({
@@ -385,7 +372,7 @@ describe("ConfigArray", () => {
 				},
 			],
 			expectedError:
-				'Config Error: Config (unnamed): Key "ignores": Expected value to be an array.',
+				/ConfigError: Config \(unnamed\): Key "ignores": Expected value to be an array\./u,
 		});
 
 		testValidationError({
@@ -397,7 +384,7 @@ describe("ConfigArray", () => {
 				},
 			],
 			expectedError:
-				'Config "foo": Key "ignores": Expected array to only contain strings and functions.',
+				/Config "foo": Key "ignores": Expected array to only contain strings and functions\./u,
 		});
 
 		testValidationError({
@@ -410,7 +397,7 @@ describe("ConfigArray", () => {
 				},
 			],
 			expectedError:
-				'Config "foo": Key "ignores": Expected array to only contain strings and functions.',
+				/Config "foo": Key "ignores": Expected array to only contain strings and functions\./u,
 		});
 
 		it("should throw an error when a config is not an object", () => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Fixes error message checking in several config-array tests.

#### What changes did you make? (Give an overview)

* Fixed `testValidationError` helper function to treat `expectedError` argument as a regex that should be passed to `assert.throws()` as that's how it is used in the tests.
* Updated two calls to pass a regex because strings don't really check error messages.
* Simplified checks for `configArray.normalize()` to use `assert.rejects()`.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
