### PR TITLE
feat: Set type for RuleDefinition.defaultOptions

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -141,6 +141,7 @@ export interface RulesMetaDocs {
  */
 export interface RulesMeta<
 	MessageIds extends string = string,
+	RuleOptions = unknown[],
 	ExtRuleDocs = unknown,
 > {
 	/**
@@ -158,8 +159,10 @@ export interface RulesMeta<
 	 */
 	schema?: JSONSchema4 | JSONSchema4[] | false | undefined;
 
-	/** Any default options to be recursively merged on top of any user-provided options. */
-	defaultOptions?: unknown[];
+	/**
+	 * Any default options to be recursively merged on top of any user-provided options.
+	 **/
+	defaultOptions?: RuleOptions;
 
 	/**
 	 * The messages that the rule can report.
@@ -561,7 +564,11 @@ export interface RuleDefinition<
 	/**
 	 * The meta information for the rule.
 	 */
-	meta?: RulesMeta<Options["MessageIds"], Options["ExtRuleDocs"]>;
+	meta?: RulesMeta<
+		Options["MessageIds"],
+		Options["RuleOptions"],
+		Options["ExtRuleDocs"]
+	>;
 
 	/**
 	 * Creates the visitor that ESLint uses to apply the rule during traversal.

--- a/packages/core/tests/types/types.test.ts
+++ b/packages/core/tests/types/types.test.ts
@@ -317,8 +317,14 @@ const testRuleWithInvalidDefaultOptions: RuleDefinition<{
 			},
 		],
 
-		// @ts-expect-error invalid default option "baz"
-		defaultOptions: [{ foo: "always", bar: 5, baz: "invalid" }],
+		defaultOptions: [
+			{
+				foo: "always",
+				bar: 5,
+				// @ts-expect-error invalid default option "baz"
+				baz: "invalid",
+			},
+		],
 	},
 
 	create(): TestRuleVisitor {

--- a/packages/core/tests/types/types.test.ts
+++ b/packages/core/tests/types/types.test.ts
@@ -290,3 +290,40 @@ const testRule: RuleDefinition<{
 };
 
 testRule.meta satisfies RulesMeta | undefined;
+
+const testRuleWithInvalidDefaultOptions: RuleDefinition<{
+	LangOptions: TestLanguageOptions;
+	Code: TestSourceCode;
+	RuleOptions: [{ foo: string; bar: number }];
+	Visitor: TestRuleVisitor;
+	Node: TestNode;
+	MessageIds: "badFoo" | "wrongBar";
+	ExtRuleDocs: never;
+}> = {
+	meta: {
+		type: "problem",
+		schema: [
+			{
+				type: "object",
+				properties: {
+					foo: {
+						type: "string",
+					},
+					bar: {
+						type: "integer",
+					},
+				},
+				additionalProperties: false,
+			},
+		],
+
+		// @ts-expect-error invalid default option "baz"
+		defaultOptions: [{ foo: "always", bar: 5, baz: "invalid" }],
+	},
+
+	create(): TestRuleVisitor {
+		return {};
+	},
+};
+
+testRuleWithInvalidDefaultOptions.meta satisfies RulesMeta | undefined;


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

I realized that `defaultOptions` can be assigned the same type as the rule options for rules to allow for better type validation.

#### What changes did you make? (Give an overview)

- Updated the `RulesMeta` to accept `RuleOptions` as an argument
- Updated `defaultOptions` to be the same type as `RuleOptions`

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
