### PR TITLE
feat: add core types for language-specific rule definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "got": "^14.4.1",
     "lint-staged": "^15.2.0",
     "prettier": "^3.4.1",
-    "typescript": "^5.5.3",
+    "typescript": "^5.8.3",
     "typescript-eslint": "^8.0.0",
     "yorkie": "^2.0.0"
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,7 +40,6 @@
     "@types/json-schema": "^7.0.15"
   },
   "devDependencies": {
-    "json-schema": "^0.4.0",
     "typescript": "^5.8.3"
   },
   "engines": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "json-schema": "^0.4.0",
-    "typescript": "^5.4.5"
+    "typescript": "^5.8.3"
   },
   "engines": {
     "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -6,7 +6,7 @@
 // Imports
 //------------------------------------------------------------------------------
 
-import { JSONSchema4 } from "json-schema";
+import type { JSONSchema4 } from "json-schema";
 
 //------------------------------------------------------------------------------
 // Helper Types
@@ -585,6 +585,50 @@ export interface RuleDefinition<
 		}>,
 	): Options["Visitor"];
 }
+
+/**
+ * Defaults for non-language-related `RuleDefinition` options.
+ */
+export interface CustomRuleTypeDefinitions {
+	RuleOptions: unknown[];
+	MessageIds: string;
+	ExtRuleDocs: Record<string, unknown>;
+}
+
+/**
+ * A helper type to define language specific specializations of the `RuleDefinition` type.
+ *
+ * @example
+ * ```ts
+ * type YourRuleDefinition<
+ * 	Options extends Partial<CustomRuleTypeDefinitions> = {},
+ * > = CustomRuleDefinitionType<
+ * 	{
+ * 		LangOptions: YourLanguageOptions;
+ * 		Code: YourSourceCode;
+ * 		Visitor: YourRuleVisitor;
+ * 		Node: YourNode;
+ * 	},
+ * 	Options
+ * >;
+ * ```
+ */
+export type CustomRuleDefinitionType<
+	LanguageSpecificOptions extends Omit<
+		RuleDefinitionTypeOptions,
+		keyof CustomRuleTypeDefinitions
+	>,
+	Options extends Partial<CustomRuleTypeDefinitions>,
+> = RuleDefinition<
+	// Language specific type options (non-configurable)
+	LanguageSpecificOptions &
+		Required<
+			// Rule specific type options (custom)
+			Options &
+				// Rule specific type options (defaults)
+				Omit<CustomRuleTypeDefinitions, keyof Options>
+		>
+>;
 
 //------------------------------------------------------------------------------
 // Config

--- a/packages/core/tests/types/tsconfig.json
+++ b/packages/core/tests/types/tsconfig.json
@@ -1,9 +1,11 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
     "noEmit": true,
     "rootDir": "../..",
-    "strict": true
+    "strict": true,
+    "verbatimModuleSyntax": true
   },
   "include": [".", "../../dist"]
 }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

fix #177

#### What changes did you make? (Give an overview)

Updated `@eslint/core`:
* Added types `CustomRuleTypeDefinitions` and `CustomRuleDefinitionType` and updated tests.
* Added options to the test TS config to make the tests stricter.
* Updated `package.json` to use the latest TypeScript version.
* Removed unused dev dependency `json-schema` since only `@types/json-schema` is required.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
