### PR TITLE
chore: fix release-please PR title

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
   "plugins": ["node-workspace"],
   "bump-minor-pre-major": true,
   "separate-pull-requests": true,
+  "pull-request-title-pattern": "chore: release${component} ${version}",
   "packages": {
     "packages/compat": {
       "release-type": "node",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Fix the title of release-please PRs.

#### What changes did you make? (Give an overview)

It seems that eslint-github-bot doesn't like the default title of pull requests created by release-please with the `"separate-pull-requests": true` setting (e.g. #187). This PR fixes the title format by removing the branch name after the tag.

Before:

> chore(main): release core 0.14.0

After:

> chore: release core 0.14.0

#### Related Issues

#183

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
