### PR TITLE
chore: remove unused `@ts-ignore` comment

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@eslint/config-helpers": "file:packages/config-helpers",
     "@types/mocha": "^10.0.7",
-    "eslint": "^9.11.1",
+    "eslint": "^9.27.0",
     "eslint-config-eslint": "^11.0.0",
     "got": "^14.4.1",
     "lint-staged": "^15.2.0",

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@eslint/core": "^0.14.0",
     "c8": "^9.1.0",
-    "eslint": "^9.11.0",
+    "eslint": "^9.27.0",
     "mocha": "^10.4.0",
     "rollup": "^4.16.2",
     "typescript": "^5.4.5"

--- a/packages/config-helpers/package.json
+++ b/packages/config-helpers/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@eslint/core": "^0.14.0",
     "c8": "^9.1.0",
-    "eslint": "^9.19.0",
+    "eslint": "^9.27.0",
     "mocha": "^10.4.0",
     "rollup": "^4.16.2",
     "rollup-plugin-copy": "^3.5.0",

--- a/packages/config-helpers/src/define-config.js
+++ b/packages/config-helpers/src/define-config.js
@@ -136,7 +136,6 @@ function getPluginMember(id) {
  * @return {Config} The normalized config object.
  */
 function normalizePluginConfig(userNamespace, plugin, config) {
-	// @ts-ignore -- ESLint types aren't updated yet
 	const pluginNamespace = plugin.meta?.namespace;
 
 	// don't do anything if the plugin doesn't have a namespace or rules

--- a/packages/migrate-config/package.json
+++ b/packages/migrate-config/package.json
@@ -38,7 +38,7 @@
   "homepage": "https://github.com/eslint/rewrite#readme",
   "devDependencies": {
     "@types/eslint": "^9.6.0",
-    "eslint": "^9.0.0",
+    "eslint": "^9.27.0",
     "mocha": "^10.4.0",
     "typescript": "^5.4.5"
   },

--- a/templates/package/package.json
+++ b/templates/package/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@eslint/core": "^0.14.0",
     "c8": "^9.1.0",
-    "eslint": "^9.11.0",
+    "eslint": "^9.27.0",
     "mocha": "^10.4.0",
     "rollup": "^4.16.2",
     "rollup-plugin-copy": "^3.5.0",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

As of ESLint v9.26.0, `Plugin.meta` type has the `namespace` property (https://github.com/eslint/eslint/commit/9736d5d15870c9185da7d140becb9a15aa69057d).

This removes an now-unnecessary `@ts-ignore` comment and bumps eslint to v9.27.0 in dev dependencies in all projects.

#### What changes did you make? (Give an overview)

Removed the mentioned `@ts-ignore` comment and updated package.json files.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
