### PR TITLE
feat: Add extendable config types

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -59,6 +59,7 @@ export default defineConfig([
 	// TypeScript
 	...tseslint.config({
 		files: ["**/*.ts"],
+		ignores: ["**/tests/**/*.ts"],
 		extends: [...tseslint.configs.strict, ...tseslint.configs.stylistic],
 		rules: {
 			"no-use-before-define": "off",

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -666,22 +666,36 @@ export interface LinterOptionsConfig {
 	 * Indicates what to do when an unused disable directive is found.
 	 */
 	reportUnusedDisableDirectives?: boolean | Severity;
-}
 
-/**
- * Shared settings that are accessible from within plugins.
- */
-export type SettingsConfig = Record<string, unknown>;
+	/**
+	 * A severity value indicating if and how unused inline configs should be
+	 * tracked and reported.
+	 */
+	reportUnusedInlineConfigs?: Severity;
+}
 
 /**
  * The configuration for a rule.
  */
-export type RuleConfig = Severity | [Severity, ...unknown[]];
+export type RuleConfig<RuleOptions extends unknown[] = unknown[]> =
+	| Severity
+	| [Severity, ...RuleOptions];
 
+/* eslint-disable @typescript-eslint/consistent-indexed-object-style -- needed to allow extension */
 /**
  * A collection of rules and their configurations.
  */
-export type RulesConfig = Record<string, RuleConfig>;
+export interface RulesConfig {
+	[key: string]: RuleConfig;
+}
+
+/**
+ * A collection of settings.
+ */
+export interface SettingsConfig {
+	[key: string]: unknown;
+}
+/* eslint-enable @typescript-eslint/consistent-indexed-object-style -- needed to allow extension */
 
 //------------------------------------------------------------------------------
 // Languages

--- a/packages/core/tests/types/types.test.ts
+++ b/packages/core/tests/types/types.test.ts
@@ -73,7 +73,7 @@ const ruleConfig1: RuleConfig = "error";
 const ruleConfig2: RuleConfig = 1;
 const ruleConfig3: RuleConfig = ["error", { foo: "bar" }];
 const ruleConfig4: RuleConfig<string[]> = ["error", "foo", "bar"];
-const ruelConfig5: RuleConfig<[{ available: "widely" | "newly" }]> = [
+const ruleConfig5: RuleConfig<[{ available: "widely" | "newly" }]> = [
 	"error",
 	{ available: "widely" },
 ];

--- a/packages/core/tests/types/types.test.ts
+++ b/packages/core/tests/types/types.test.ts
@@ -15,8 +15,10 @@ import type {
 	Language,
 	LanguageContext,
 	LanguageOptions,
+	LinterOptionsConfig,
 	OkParseResult,
 	ParseResult,
+	RuleConfig,
 	RuleContext,
 	RuleDefinition,
 	RulesConfig,
@@ -24,6 +26,7 @@ import type {
 	RuleTextEdit,
 	RuleTextEditor,
 	RuleVisitor,
+	SettingsConfig,
 	SourceLocation,
 	SourceRange,
 	TextSourceCode,
@@ -45,6 +48,41 @@ interface TestRootNode {
 	start: number;
 	length: number;
 }
+
+//-----------------------------------------------------------------------------
+// Tests for config types
+//-----------------------------------------------------------------------------
+
+const emptyRules: RulesConfig = {};
+
+const rules: RulesConfig = {
+	"no-console": "error",
+	"no-unused-vars": 0,
+	"json/no-duplicate-keys": ["warn"],
+	"css/use-baseline": [1, { available: "widely" }],
+};
+
+const emptySettings: SettingsConfig = {};
+
+const settings: SettingsConfig = {
+	foo: true,
+	bar: "baz",
+};
+
+const ruleConfig1: RuleConfig = "error";
+const ruleConfig2: RuleConfig = 1;
+const ruleConfig3: RuleConfig = ["error", { foo: "bar" }];
+const ruleConfig4: RuleConfig<string[]> = ["error", "foo", "bar"];
+const ruelConfig5: RuleConfig<[{ available: "widely" | "newly" }]> = [
+	"error",
+	{ available: "widely" },
+];
+
+const linterConfig: LinterOptionsConfig = {
+	noInlineConfig: true,
+	reportUnusedDisableDirectives: "error",
+	reportUnusedInlineConfigs: "warn",
+};
 
 //-----------------------------------------------------------------------------
 // Tests for shared types


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Adds interfaces for `settings` and `rules` can be extended by plugins.

#### What changes did you make? (Give an overview)

- Added `SettingsConfig` interface
- Added `RulesConfig` interface
- Updated `LinterOptionsConfig` interface (for completeness)
- Updated types tests

#### Related Issues

fixes #208
<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

Just a note that once this is released, we'll need to update the `Config` type in the `eslint` package.

<!-- markdownlint-disable-file MD004 -->
