### PR TITLE
fix: relax `@eslint/compat` eslint peerDependencies constraint

### DIFF
--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -56,7 +56,7 @@
     "typescript": "^5.4.5"
   },
   "peerDependencies": {
-    "eslint": "^9.10.0"
+    "eslint": "^8.40 || 9"
   },
   "peerDependenciesMeta": {
     "eslint": {


### PR DESCRIPTION
Updated to the suggestion in https://github.com/eslint/rewrite/pull/106#issuecomment-2525696320. This was a breaking change, causing a refresh of our lockfile to generate the following error:

```
 ERR_PNPM_PEER_DEP_ISSUES  Unmet peer dependencies

XXX
└─┬ @eslint/compat 1.2.9
  └── ✕ unmet peer eslint@^9.10.0: found 8.57.0
```

This resolves the breaking change, since I believe @eslint/compat was introduced during the v8 eslint cycle and we don't need to go lower.

<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

To resolve a breaking change in @eslint/compat.

#### What changes did you make? (Give an overview)

Added eslint v8 to the peer dependencies.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->
https://github.com/eslint/rewrite/pull/106#issuecomment-2525696320

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
