### PR TITLE
fix: explicit match in array elements of `files`

### DIFF
--- a/packages/config-array/src/config-array.js
+++ b/packages/config-array/src/config-array.js
@@ -1013,6 +1013,15 @@ export class ConfigArray extends Array {
 			const nonUniversalFiles = [];
 			const universalFiles = config.files.filter(element => {
 				if (Array.isArray(element)) {
+					/*
+					 * filePath matches an element that is an array only if it matches
+					 * all patterns in it (AND operation). Therefore, if there is at least
+					 * one non-universal pattern in the array, and filePath matches the array,
+					 * then we know for sure that filePath matches at least one non-universal
+					 * pattern, so we can consider the entire array to be non-universal.
+					 * In other words, all patterns in the array need to be universal
+					 * for it to be considered universal.
+					 */
 					if (
 						element.every(pattern => universalPattern.test(pattern))
 					) {

--- a/packages/config-array/src/config-array.js
+++ b/packages/config-array/src/config-array.js
@@ -1010,17 +1010,32 @@ export class ConfigArray extends Array {
 			 * a file with a specific extensions such as *.js.
 			 */
 
-			const universalFiles = config.files.filter(pattern =>
-				universalPattern.test(pattern),
-			);
+			const nonUniversalFiles = [];
+			const universalFiles = config.files.filter(element => {
+				if (Array.isArray(element)) {
+					if (
+						element.every(pattern => universalPattern.test(pattern))
+					) {
+						return true;
+					}
+
+					nonUniversalFiles.push(element);
+					return false;
+				}
+
+				// element is a string
+
+				if (universalPattern.test(element)) {
+					return true;
+				}
+
+				nonUniversalFiles.push(element);
+				return false;
+			});
 
 			// universal patterns were found so we need to check the config twice
 			if (universalFiles.length) {
 				debug("Universal files patterns found. Checking carefully.");
-
-				const nonUniversalFiles = config.files.filter(
-					pattern => !universalPattern.test(pattern),
-				);
 
 				// check that the config matches without the non-universal files first
 				if (

--- a/packages/config-array/tests/config-array.test.js
+++ b/packages/config-array/tests/config-array.test.js
@@ -1833,6 +1833,39 @@ describe("ConfigArray", () => {
 				);
 			});
 
+			it('should return "matched" when there is at least one non-universal match, "unconfigured" otherwise', () => {
+				[
+					[["**/*.js", "foo/**"]],
+					[["foo/**", "**/*.js"]],
+					[["**/*.js", "foo/**"], "bar/**"],
+					[["foo/**", "**/*.js"], "bar/**"],
+					[["bar/**"], "foo/*.js"],
+				].forEach(files => {
+					configs = new ConfigArray(
+						[
+							{
+								files,
+							},
+						],
+						{
+							basePath,
+						},
+					);
+
+					configs.normalizeSync();
+
+					assert.strictEqual(
+						configs.getConfigStatus("foo/a.js"),
+						"matched",
+					);
+
+					assert.strictEqual(
+						configs.getConfigStatus("bar/a.js"),
+						"unconfigured",
+					);
+				});
+			});
+
 			it('should return "matched" when file has the same name as a directory that is ignored by a pattern that ends with `/`', () => {
 				configs = new ConfigArray(
 					[

--- a/packages/config-array/tests/config-array.test.js
+++ b/packages/config-array/tests/config-array.test.js
@@ -883,6 +883,34 @@ describe("ConfigArray", () => {
 				assert.strictEqual(config2, undefined);
 			});
 
+			it("should match any filename with a config object that has `[]` in files", () => {
+				configs = new ConfigArray(
+					[
+						{
+							files: [[]],
+							defs: {
+								"test-def": "test-value",
+							},
+						},
+						{
+							files: ["**/*.js"], // `[]` is not an explicit match, so we need to add an explicit match
+						},
+					],
+					{
+						basePath,
+						schema,
+					},
+				);
+
+				configs.normalizeSync();
+
+				assert.deepStrictEqual(configs.getConfig("foo/a.js"), {
+					defs: {
+						"test-def": "test-value",
+					},
+				});
+			});
+
 			it("should calculate correct config when passed JS filename that matches a async function config", () => {
 				const configsToTest = createConfigArray();
 				configsToTest.push(context =>
@@ -1840,6 +1868,7 @@ describe("ConfigArray", () => {
 					[["**/*.js", "foo/**"], "bar/**"],
 					[["foo/**", "**/*.js"], "bar/**"],
 					[["bar/**"], "foo/*.js"],
+					[[], "foo/*.js"],
 				].forEach(files => {
 					configs = new ConfigArray(
 						[


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Fixes the problem described in https://github.com/eslint/eslint/issues/19814.

#### What changes did you make? (Give an overview)

Fixed the code that checks for explicit matches in `files` to account for array elements of `files`.

#### Related Issues

https://github.com/eslint/eslint/issues/19814

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
