### PR TITLE
fix: consider negated patterns universal

### DIFF
--- a/packages/config-array/src/config-array.js
+++ b/packages/config-array/src/config-array.js
@@ -979,7 +979,7 @@ export class ConfigArray extends Array {
 
 		const matchingConfigIndices = [];
 		let matchFound = false;
-		const universalPattern = /^\*$|\/\*{1,2}$/u;
+		const universalPattern = /^\*$|^!|\/\*{1,2}$/u;
 
 		this.forEach((config, index) => {
 			if (!config.files) {

--- a/packages/config-array/tests/config-array.test.js
+++ b/packages/config-array/tests/config-array.test.js
@@ -1525,12 +1525,12 @@ describe("ConfigArray", () => {
 				);
 			});
 
-			it('should return "matched" when passed docx filename', () => {
+			it('should return "unconfigured" when passed docx filename', () => {
 				const filename = "sss.docx";
 
 				assert.strictEqual(
 					configs.getConfigStatus(filename),
-					"matched",
+					"unconfigured",
 				);
 			});
 
@@ -1869,6 +1869,8 @@ describe("ConfigArray", () => {
 					[["foo/**", "**/*.js"], "bar/**"],
 					[["bar/**"], "foo/*.js"],
 					[[], "foo/*.js"],
+					[["bar/**", "!bar/b.js"], "foo/*.js"],
+					["!b.js", "foo/*.js"],
 				].forEach(files => {
 					configs = new ConfigArray(
 						[


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Fixes the problem described in https://github.com/eslint/eslint/issues/19813.

#### What changes did you make? (Give an overview)

Updated regex pattern that checks for universal patterns to treat negated patterns as such.

#### Related Issues

https://github.com/eslint/eslint/issues/19813

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
