### PR TITLE
fix: Allow RuleConfig to have array with just severity

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -679,6 +679,7 @@ export interface LinterOptionsConfig {
  */
 export type RuleConfig<RuleOptions extends unknown[] = unknown[]> =
 	| Severity
+	| [Severity]
 	| [Severity, ...RuleOptions];
 
 /* eslint-disable @typescript-eslint/consistent-indexed-object-style -- needed to allow extension */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -679,8 +679,7 @@ export interface LinterOptionsConfig {
  */
 export type RuleConfig<RuleOptions extends unknown[] = unknown[]> =
 	| Severity
-	| [Severity]
-	| [Severity, ...RuleOptions];
+	| [Severity, ...Partial<RuleOptions>];
 
 /* eslint-disable @typescript-eslint/consistent-indexed-object-style -- needed to allow extension */
 /**

--- a/packages/core/tests/types/types.test.ts
+++ b/packages/core/tests/types/types.test.ts
@@ -77,6 +77,7 @@ const ruleConfig5: RuleConfig<[{ available: "widely" | "newly" }]> = [
 	"error",
 	{ available: "widely" },
 ];
+const ruleConfig6: RuleConfig<["always" | "never"]> = ["error"];
 
 const linterConfig: LinterOptionsConfig = {
 	noInlineConfig: true,


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

To allow rule configs to have an array with just a severity:

```js
{
    rules: {
        semi: ["error"]
    }
}
```

#### What changes did you make? (Give an overview)

- Updated `RuleConfig` to also match `[Severity]`.
- Updated types tests to verify this change.

#### Related Issues

Split from https://github.com/eslint/eslint/pull/19843#discussion_r2142999877

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
