### PR TITLE
fix: Add missing peer dependencies to `@eslint/config-helpers`

### DIFF
--- a/packages/config-helpers/package.json
+++ b/packages/config-helpers/package.json
@@ -51,6 +51,14 @@
     "eslint": "^9.27.0",
     "rollup-plugin-copy": "^3.5.0"
   },
+  "peerDependencies": {
+    "eslint": "^8.40 || 9"
+  },
+  "peerDependenciesMeta": {
+    "eslint": {
+      "optional": true
+    }
+  },
   "engines": {
     "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
   }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Fix types resolving issues in my project. It's resolving to an outdated `@types/eslint` instead of `eslint`

#### What changes did you make? (Give an overview)

Copy peer dependencies from `@eslint/compat`

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
