### PR TITLE
chore: update dependency minimatch to ^9.0.5

### DIFF
--- a/packages/config-array/package.json
+++ b/packages/config-array/package.json
@@ -50,11 +50,10 @@
   "dependencies": {
     "@eslint/object-schema": "^2.1.6",
     "debug": "^4.3.1",
-    "minimatch": "^3.1.2"
+    "minimatch": "^9.0.5"
   },
   "devDependencies": {
     "@jsr/std__path": "^1.0.4",
-    "@types/minimatch": "^3.0.5",
     "rollup-plugin-copy": "^3.5.0"
   },
   "engines": {

--- a/packages/config-array/src/config-array.js
+++ b/packages/config-array/src/config-array.js
@@ -9,7 +9,7 @@
 
 import * as posixPath from "@jsr/std__path/posix";
 import * as windowsPath from "@jsr/std__path/windows";
-import minimatch from "minimatch";
+import { minimatch } from "minimatch";
 import createDebug from "debug";
 
 import { ObjectSchema } from "@eslint/object-schema";
@@ -23,8 +23,7 @@ import { filesAndIgnoresSchema } from "./files-and-ignores-schema.js";
 /** @typedef {import("@eslint/object-schema").PropertyDefinition} PropertyDefinition */
 /** @typedef {import("@eslint/object-schema").ObjectDefinition} ObjectDefinition */
 /** @typedef {import("./types.ts").ConfigObject} ConfigObject */
-/** @typedef {import("minimatch").IMinimatchStatic} IMinimatchStatic */
-/** @typedef {import("minimatch").IMinimatch} IMinimatch */
+/** @typedef {import("minimatch").Minimatch} Minimatch */
 /** @typedef {import("@jsr/std__path")} PathImpl */
 
 /*
@@ -45,13 +44,13 @@ const debug = createDebug("@eslint/config-array");
 
 /**
  * A cache for minimatch instances.
- * @type {Map<string, IMinimatch>}
+ * @type {Map<string, Minimatch>}
  */
 const minimatchCache = new Map();
 
 /**
  * A cache for negated minimatch instances.
- * @type {Map<string, IMinimatch>}
+ * @type {Map<string, Minimatch>}
  */
 const negatedMinimatchCache = new Map();
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This PR updates the `minimatch` dependency to ^9.0.5 to address security vulnerabilities.

#### What changes did you make? (Give an overview)

- Updated minimatch dependency
- Modified the import statement from default import to named import to accommodate minimatch v9's breaking change where default exports were removed
- Chose version 9.0.5 instead of the latest v10 to maintain compatibility with Node.js v18, which is the minimum supported version for this project
- Ensured all tests pass both in this repository and in the main ESLint repository to confirm the update doesn't break existing functionality

#### Related Issues

Fixes #230 
Fixes #66

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
