### PR TITLE
feat: Add config types in @eslint/core

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -62,6 +62,10 @@ export default defineConfig([
 		ignores: ["**/tests/**/*.ts"],
 		extends: [...tseslint.configs.strict, ...tseslint.configs.stylistic],
 		rules: {
+			"@typescript-eslint/array-type": [
+				"error",
+				{ default: "generic", readonly: "array" },
+			],
 			"no-use-before-define": "off",
 		},
 	}),

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -48,8 +48,10 @@
     "url": "https://github.com/eslint/rewrite/issues"
   },
   "homepage": "https://github.com/eslint/rewrite/tree/main/packages/compat#readme",
+  "dependencies": {
+    "@eslint/core": "^0.15.1"
+  },
   "devDependencies": {
-    "@eslint/core": "^0.15.1",
     "eslint": "^9.27.0"
   },
   "peerDependencies": {

--- a/packages/compat/src/fixup-rules.js
+++ b/packages/compat/src/fixup-rules.js
@@ -7,10 +7,10 @@
 // Types
 //-----------------------------------------------------------------------------
 
-/** @typedef {import("eslint").ESLint.Plugin} FixupPluginDefinition */
-/** @typedef {import("eslint").Rule.RuleModule} FixupRuleDefinition */
+/** @typedef {import("@eslint/core").Plugin} FixupPluginDefinition */
+/** @typedef {import("@eslint/core").RuleDefinition} FixupRuleDefinition */
 /** @typedef {FixupRuleDefinition["create"]} FixupLegacyRuleDefinition */
-/** @typedef {import("eslint").Linter.Config} FixupConfig */
+/** @typedef {import("@eslint/core").ConfigObject} FixupConfig */
 /** @typedef {Array<FixupConfig>} FixupConfigArray */
 
 //-----------------------------------------------------------------------------

--- a/packages/compat/src/ignore-file.js
+++ b/packages/compat/src/ignore-file.js
@@ -14,7 +14,7 @@ import path from "node:path";
 // Types
 //-----------------------------------------------------------------------------
 
-/** @typedef {import("eslint").Linter.Config} FlatConfig */
+/** @typedef {import("@eslint/core").ConfigObject} FlatConfig */
 
 //-----------------------------------------------------------------------------
 // Exports

--- a/packages/config-helpers/package.json
+++ b/packages/config-helpers/package.json
@@ -46,8 +46,10 @@
     "url": "https://github.com/eslint/rewrite/issues"
   },
   "homepage": "https://github.com/eslint/rewrite/tree/main/packages/config-helpers#readme",
+  "dependencies": {
+    "@eslint/core": "^0.15.1"
+  },
   "devDependencies": {
-    "@eslint/core": "^0.15.1",
     "eslint": "^9.27.0",
     "rollup-plugin-copy": "^3.5.0"
   },

--- a/packages/config-helpers/src/define-config.js
+++ b/packages/config-helpers/src/define-config.js
@@ -7,10 +7,10 @@
 // Type Definitions
 //-----------------------------------------------------------------------------
 
-/** @typedef {import("eslint").Linter.Config} Config */
-/** @typedef {import("eslint").Linter.LegacyConfig} LegacyConfig */
-/** @typedef {import("eslint").ESLint.Plugin} Plugin */
-/** @typedef {import("eslint").Linter.RuleEntry} RuleEntry */
+/** @typedef {import("@eslint/core").ConfigObject} Config */
+/** @typedef {import("@eslint/core").LegacyConfigObject} LegacyConfig */
+/** @typedef {import("@eslint/core").Plugin} Plugin */
+/** @typedef {import("@eslint/core").RuleConfig} RuleConfig */
 /** @typedef {import("./types.ts").ExtendsElement} ExtendsElement */
 /** @typedef {import("./types.ts").SimpleExtendsElement} SimpleExtendsElement */
 /** @typedef {import("./types.ts").ConfigWithExtends} ConfigWithExtends */
@@ -153,7 +153,7 @@ function normalizePluginConfig(userNamespace, plugin, config) {
 	if (result.rules) {
 		const ruleIds = Object.keys(result.rules);
 
-		/** @type {Record<string,RuleEntry|undefined>} */
+		/** @type {Record<string,RuleConfig|undefined>} */
 		const newRules = {};
 
 		for (let i = 0; i < ruleIds.length; i++) {

--- a/packages/config-helpers/src/global-ignores.js
+++ b/packages/config-helpers/src/global-ignores.js
@@ -7,7 +7,7 @@
 // Type Definitions
 //-----------------------------------------------------------------------------
 
-/** @typedef {import("eslint").Linter.Config} Config */
+/** @typedef {import("@eslint/core").ConfigObject} Config */
 
 //-----------------------------------------------------------------------------
 // Helpers

--- a/packages/config-helpers/src/types.ts
+++ b/packages/config-helpers/src/types.ts
@@ -2,30 +2,28 @@
  * @fileoverview Types for this package.
  */
 
-import type { Linter } from "eslint";
+import type { ConfigObject } from "@eslint/core";
 
 /**
  * Infinite array type.
  */
-export type InfiniteArray<T> = T | InfiniteArray<T>[];
+export type InfiniteArray<T> = T | Array<InfiniteArray<T>>;
 
 /**
  * The type of array element in the `extends` property after flattening.
  */
-export type SimpleExtendsElement = string | Linter.Config;
+export type SimpleExtendsElement = string | ConfigObject;
 
 /**
  * The type of array element in the `extends` property before flattening.
  */
-export type ExtendsElement =
-	| SimpleExtendsElement
-	| InfiniteArray<Linter.Config>;
+export type ExtendsElement = SimpleExtendsElement | InfiniteArray<ConfigObject>;
 
 /**
  * Config with extends. Valid only inside of `defineConfig()`.
  */
-export interface ConfigWithExtends extends Linter.Config {
-	extends?: ExtendsElement[];
+export interface ConfigWithExtends extends ConfigObject {
+	extends?: Array<ExtendsElement>;
 }
 
-export type ConfigWithExtendsArray = InfiniteArray<ConfigWithExtends>[];
+export type ConfigWithExtendsArray = Array<InfiniteArray<ConfigWithExtends>>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -100,7 +100,7 @@ export type RuleFixType = "code" | "whitespace";
  */
 export type RuleVisitor = Record<
 	string,
-	((...args: any[]) => void) | undefined
+	((...args: Array<any>) => void) | undefined
 >;
 
 /* eslint-enable @typescript-eslint/no-explicit-any -- Necessary to allow subclasses to work correctly */
@@ -141,7 +141,7 @@ export interface RulesMetaDocs {
  */
 export interface RulesMeta<
 	MessageIds extends string = string,
-	RuleOptions = unknown[],
+	RuleOptions = Array<unknown>,
 	ExtRuleDocs = unknown,
 > {
 	/**
@@ -157,7 +157,7 @@ export interface RulesMeta<
 	/**
 	 * The schema for the rule options. Required if the rule has options.
 	 */
-	schema?: JSONSchema4 | JSONSchema4[] | false | undefined;
+	schema?: JSONSchema4 | Array<JSONSchema4> | false | undefined;
 
 	/**
 	 * Any default options to be recursively merged on top of any user-provided options.
@@ -198,7 +198,7 @@ export interface RulesMeta<
 	/**
 	 * The dialects of `language` that the rule is intended to lint.
 	 */
-	dialects?: string[];
+	dialects?: Array<string>;
 }
 
 /**
@@ -219,7 +219,7 @@ export interface DeprecatedInfo {
 	/**
 	 * An empty array explicitly states that there is no replacement.
 	 */
-	replacedBy?: ReplacedByInfo[];
+	replacedBy?: Array<ReplacedByInfo>;
 
 	/**
 	 * The package version since when the rule is deprecated (should use full
@@ -283,7 +283,7 @@ export interface ExternalSpecifier {
 export interface RuleContextTypeOptions {
 	LangOptions: LanguageOptions;
 	Code: SourceCode;
-	RuleOptions: unknown[];
+	RuleOptions: Array<unknown>;
 	Node: unknown;
 	MessageIds: string;
 }
@@ -502,7 +502,7 @@ interface ViolationReportBase {
 	 * An array of suggested fixes for the problem. These fixes may change the
 	 * behavior of the code, so they are not applied automatically.
 	 */
-	suggest?: SuggestedEdit[] | null | undefined;
+	suggest?: Array<SuggestedEdit> | null | undefined;
 }
 
 type ViolationMessage<MessageIds = string> =
@@ -548,7 +548,7 @@ export type SuggestedEdit = SuggestedEditBase & SuggestionMessage;
 export interface RuleDefinitionTypeOptions {
 	LangOptions: LanguageOptions;
 	Code: SourceCode;
-	RuleOptions: unknown[];
+	RuleOptions: Array<unknown>;
 	Visitor: RuleVisitor;
 	Node: unknown;
 	MessageIds: string;
@@ -590,7 +590,7 @@ export interface RuleDefinition<
  * Defaults for non-language-related `RuleDefinition` options.
  */
 export interface CustomRuleTypeDefinitions {
-	RuleOptions: unknown[];
+	RuleOptions: Array<unknown>;
 	MessageIds: string;
 	ExtRuleDocs: Record<string, unknown>;
 }
@@ -634,6 +634,8 @@ export type CustomRuleDefinitionType<
 // Config
 //------------------------------------------------------------------------------
 
+// #region Severities
+
 /**
  * The human readable severity level used in a configuration.
  */
@@ -652,6 +654,24 @@ export type SeverityLevel = 0 | 1 | 2;
  * The severity of a rule in a configuration.
  */
 export type Severity = SeverityName | SeverityLevel;
+
+// #endregion
+
+/**
+ * Represents the metadata for an object, such as a plugin or processor.
+ */
+export interface ObjectMetaProperties {
+	/** @deprecated Use `meta.name` instead. */
+	name?: string | undefined;
+
+	/** @deprecated Use `meta.version` instead. */
+	version?: string | undefined;
+
+	meta?: {
+		name?: string | undefined;
+		version?: string | undefined;
+	};
+}
 
 /**
  * Represents the configuration options for the core linter.
@@ -677,7 +697,7 @@ export interface LinterOptionsConfig {
 /**
  * The configuration for a rule.
  */
-export type RuleConfig<RuleOptions extends unknown[] = unknown[]> =
+export type RuleConfig<RuleOptions extends Array<unknown> = Array<unknown>> =
 	| Severity
 	| [Severity, ...Partial<RuleOptions>];
 
@@ -696,6 +716,389 @@ export interface SettingsConfig {
 	[key: string]: unknown;
 }
 /* eslint-enable @typescript-eslint/consistent-indexed-object-style -- needed to allow extension */
+
+/**
+ * The configuration for a set of files.
+ */
+export interface ConfigObject<Rules extends RulesConfig = RulesConfig> {
+	/**
+	 * An string to identify the configuration object. Used in error messages and
+	 * inspection tools.
+	 */
+	name?: string;
+
+	/**
+	 * An array of glob patterns indicating the files that the configuration
+	 * object should apply to. If not specified, the configuration object applies
+	 * to all files
+	 */
+	files?: Array<string | Array<string>>;
+
+	/**
+	 * An array of glob patterns indicating the files that the configuration
+	 * object should not apply to. If not specified, the configuration object
+	 * applies to all files matched by files
+	 */
+	ignores?: Array<string>;
+
+	/**
+	 * The name of the language used for linting. This is used to determine the
+	 * parser and other language-specific settings.
+	 * @since 9.7.0
+	 */
+	language?: string;
+
+	/**
+	 * An object containing settings related to how JavaScript is configured for
+	 * linting.
+	 */
+	languageOptions?: LanguageOptions;
+
+	/**
+	 * An object containing settings related to the linting process
+	 */
+	linterOptions?: LinterOptionsConfig;
+
+	/**
+	 * Either an object containing preprocess() and postprocess() methods or a
+	 * string indicating the name of a processor inside of a plugin
+	 * (i.e., "pluginName/processorName").
+	 */
+	processor?: string | Processor;
+
+	/**
+	 * An object containing a name-value mapping of plugin names to plugin objects.
+	 * When files is specified, these plugins are only available to the matching files.
+	 */
+	plugins?: Record<string, Plugin>;
+
+	/**
+	 * An object containing the configured rules. When files or ignores are specified,
+	 * these rule configurations are only available to the matching files.
+	 */
+	rules?: Partial<Rules>;
+
+	/**
+	 * An object containing name-value pairs of information that should be
+	 * available to all rules.
+	 */
+	settings?: Record<string, unknown>;
+}
+
+//------------------------------------------------------------------------------
+// Legacy Config
+// https://eslint.org/docs/latest/use/configure/configuration-files#legacy-config
+//------------------------------------------------------------------------------
+
+/* eslint-disable @typescript-eslint/consistent-indexed-object-style, @typescript-eslint/no-explicit-any -- needed for backward compatibility */
+
+/** @deprecated Only supported in legacy eslintrc config format. */
+export type GlobalAccess =
+	| boolean
+	| "off"
+	| "readable"
+	| "readonly"
+	| "writable"
+	| "writeable";
+
+/** @deprecated Only supported in legacy eslintrc config format. */
+export interface GlobalsConfig {
+	[name: string]: GlobalAccess;
+}
+
+/**
+ * The ECMAScript version of the code being linted.
+ */
+export type EcmaVersion =
+	| 3
+	| 5
+	| 6
+	| 7
+	| 8
+	| 9
+	| 10
+	| 11
+	| 12
+	| 13
+	| 14
+	| 15
+	| 16
+	| 17
+	| 2015
+	| 2016
+	| 2017
+	| 2018
+	| 2019
+	| 2020
+	| 2021
+	| 2022
+	| 2023
+	| 2024
+	| 2025
+	| 2026
+	| "latest";
+
+/**
+ * The type of JavaScript source code.
+ */
+type SourceType = "script" | "module" | "commonjs";
+
+/**
+ * Parser options.
+ * @deprecated Only supported in legacy eslintrc config format.
+ * @see [Specifying Parser Options](https://eslint.org/docs/latest/use/configure/language-options#specifying-parser-options)
+ */
+export interface ParserOptionsConfig {
+	/**
+	 * Allow the use of reserved words as identifiers (if `ecmaVersion` is 3).
+	 *
+	 * @default false
+	 */
+	allowReserved?: boolean | undefined;
+
+	/**
+	 * Accepts any valid ECMAScript version number or `'latest'`:
+	 *
+	 * - A version: es3, es5, es6, es7, es8, es9, es10, es11, es12, es13, es14, ..., or
+	 * - A year: es2015, es2016, es2017, es2018, es2019, es2020, es2021, es2022, es2023, ..., or
+	 * - `'latest'`
+	 *
+	 * When it's a version or a year, the value must be a number - so do not include the `es` prefix.
+	 *
+	 * Specifies the version of ECMAScript syntax you want to use. This is used by the parser to determine how to perform scope analysis, and it affects the default
+	 *
+	 * @default 5
+	 */
+	ecmaVersion?: EcmaVersion | undefined;
+
+	/**
+	 * The type of JavaScript source code. Possible values are "script" for
+	 * traditional script files, "module" for ECMAScript modules (ESM), and
+	 * "commonjs" for CommonJS files.
+	 *
+	 * @default 'script'
+	 *
+	 * @see https://eslint.org/docs/latest/use/configure/language-options-deprecated#specifying-parser-options
+	 */
+	sourceType?: SourceType | undefined;
+
+	/**
+	 * An object indicating which additional language features you'd like to use.
+	 *
+	 * @see https://eslint.org/docs/latest/use/configure/language-options-deprecated#specifying-parser-options
+	 */
+	ecmaFeatures?:
+		| {
+				globalReturn?: boolean | undefined;
+				impliedStrict?: boolean | undefined;
+				jsx?: boolean | undefined;
+				experimentalObjectRestSpread?: boolean | undefined;
+				[key: string]: any;
+		  }
+		| undefined;
+	[key: string]: any;
+}
+
+/** @deprecated Only supported in legacy eslintrc config format. */
+export interface EnvironmentConfig {
+	/** The definition of global variables. */
+	globals?: GlobalsConfig | undefined;
+
+	/** The parser options that will be enabled under this environment. */
+	parserOptions?: ParserOptionsConfig | undefined;
+}
+
+/**
+ * A configuration object that may have a `rules` block.
+ */
+interface HasRules<Rules extends RulesConfig = RulesConfig> {
+	rules?: Partial<Rules> | undefined;
+}
+
+/**
+ * ESLint legacy configuration.
+ *
+ * @see [ESLint Legacy Configuration](https://eslint.org/docs/latest/use/configure/)
+ */
+interface BaseConfig<
+	Rules extends RulesConfig = RulesConfig,
+	OverrideRules extends RulesConfig = Rules,
+> extends HasRules<Rules> {
+	$schema?: string | undefined;
+
+	/**
+	 * An environment provides predefined global variables.
+	 *
+	 * @see [Environments](https://eslint.org/docs/latest/use/configure/language-options-deprecated#specifying-environments)
+	 */
+	env?: { [name: string]: boolean } | undefined;
+
+	/**
+	 * Extending configuration files.
+	 *
+	 * @see [Extends](https://eslint.org/docs/latest/use/configure/configuration-files-deprecated#extending-configuration-files)
+	 */
+	extends?: string | Array<string> | undefined;
+
+	/**
+	 * Specifying globals.
+	 *
+	 * @see [Globals](https://eslint.org/docs/latest/use/configure/language-options-deprecated#specifying-globals)
+	 */
+	globals?: GlobalsConfig | undefined;
+
+	/**
+	 * Disable processing of inline comments.
+	 *
+	 * @see [Disabling Inline Comments](https://eslint.org/docs/latest/use/configure/rules-deprecated#disabling-inline-comments)
+	 */
+	noInlineConfig?: boolean | undefined;
+
+	/**
+	 * Overrides can be used to use a differing configuration for matching sub-directories and files.
+	 *
+	 * @see [How do overrides work](https://eslint.org/docs/latest/use/configure/configuration-files-deprecated#how-do-overrides-work)
+	 */
+	overrides?: Array<ConfigOverride<OverrideRules>> | undefined;
+
+	/**
+	 * Parser.
+	 *
+	 * @see [Working with Custom Parsers](https://eslint.org/docs/latest/extend/custom-parsers)
+	 * @see [Specifying Parser](https://eslint.org/docs/latest/use/configure/parser-deprecated)
+	 */
+	parser?: string | undefined;
+
+	/**
+	 * Parser options.
+	 *
+	 * @see [Working with Custom Parsers](https://eslint.org/docs/latest/extend/custom-parsers)
+	 * @see [Specifying Parser Options](https://eslint.org/docs/latest/use/configure/language-options-deprecated#specifying-parser-options)
+	 */
+	parserOptions?: ParserOptionsConfig | undefined;
+
+	/**
+	 * Which third-party plugins define additional rules, environments, configs, etc. for ESLint to use.
+	 *
+	 * @see [Configuring Plugins](https://eslint.org/docs/latest/use/configure/plugins-deprecated#configure-plugins)
+	 */
+	plugins?: Array<string> | undefined;
+
+	/**
+	 * Specifying processor.
+	 *
+	 * @see [processor](https://eslint.org/docs/latest/use/configure/plugins-deprecated#specify-a-processor)
+	 */
+	processor?: string | undefined;
+
+	/**
+	 * Report unused eslint-disable comments as warning.
+	 *
+	 * @see [Report unused eslint-disable comments](https://eslint.org/docs/latest/use/configure/rules-deprecated#report-unused-eslint-disable-comments)
+	 */
+	reportUnusedDisableDirectives?: boolean | undefined;
+
+	/**
+	 * Settings.
+	 *
+	 * @see [Settings](https://eslint.org/docs/latest/use/configure/configuration-files-deprecated#adding-shared-settings)
+	 */
+	settings?: SettingsConfig | undefined;
+}
+
+/**
+ * The overwrites that apply more differing configuration to specific files or directories.
+ */
+export interface ConfigOverride<Rules extends RulesConfig = RulesConfig>
+	extends BaseConfig<Rules> {
+	/**
+	 * The glob patterns for excluded files.
+	 */
+	excludedFiles?: string | Array<string> | undefined;
+
+	/**
+	 * The glob patterns for target files.
+	 */
+	files: string | Array<string>;
+}
+
+/**
+ * ESLint legacy configuration.
+ *
+ * @see [ESLint Legacy Configuration](https://eslint.org/docs/latest/use/configure/)
+ */
+// https://github.com/eslint/eslint/blob/v8.57.0/conf/config-schema.js
+export interface LegacyConfigObject<
+	Rules extends RulesConfig = RulesConfig,
+	OverrideRules extends RulesConfig = Rules,
+> extends BaseConfig<Rules, OverrideRules> {
+	/**
+	 * Tell ESLint to ignore specific files and directories.
+	 *
+	 * @see [Ignore Patterns](https://eslint.org/docs/latest/use/configure/ignore-deprecated#ignorepatterns-in-config-files)
+	 */
+	ignorePatterns?: string | Array<string> | undefined;
+
+	/**
+	 * @see [Using Configuration Files](https://eslint.org/docs/latest/use/configure/configuration-files-deprecated#using-configuration-files)
+	 */
+	root?: boolean | undefined;
+}
+
+/* eslint-enable @typescript-eslint/consistent-indexed-object-style, @typescript-eslint/no-explicit-any -- needed for backward compatibility */
+
+//------------------------------------------------------------------------------
+// Processors
+// https://eslint.org/docs/latest/extend/plugins#processors-in-plugins
+//------------------------------------------------------------------------------
+
+/**
+ * File information passed to a processor.
+ */
+export interface ProcessorFile {
+	text: string;
+	filename: string;
+}
+
+/**
+ * A processor is an object that can preprocess and postprocess files.
+ */
+export interface Processor<
+	T extends string | ProcessorFile = string | ProcessorFile,
+> extends ObjectMetaProperties {
+	/** If `true` then it means the processor supports autofix. */
+	supportsAutofix?: boolean | undefined;
+
+	/** The function to extract code blocks. */
+	preprocess?(text: string, filename: string): Array<T>;
+
+	/** The function to merge messages. */
+	postprocess?(
+		messages: Array<Array<ViolationMessage>>,
+		filename: string,
+	): Array<ViolationMessage>;
+}
+
+//------------------------------------------------------------------------------
+// Plugins
+// https://eslint.org/docs/latest/extend/plugins
+//------------------------------------------------------------------------------
+
+export interface Plugin extends ObjectMetaProperties {
+	meta?: ObjectMetaProperties["meta"] & {
+		namespace?: string | undefined;
+	};
+	configs?:
+		| Record<
+				string,
+				LegacyConfigObject | ConfigObject | Array<ConfigObject>
+		  >
+		| undefined;
+	environments?: Record<string, EnvironmentConfig> | undefined;
+	languages?: Record<string, Language> | undefined;
+	processors?: Record<string, Processor> | undefined;
+	rules?: Record<string, RuleDefinition> | undefined;
+}
 
 //------------------------------------------------------------------------------
 // Languages
@@ -745,7 +1148,7 @@ export interface Language<
 	/**
 	 * The traversal path that tools should take when evaluating the AST
 	 */
-	visitorKeys?: Record<string, string[]>;
+	visitorKeys?: Record<string, Array<string>>;
 
 	/**
 	 * Default language options. User-defined options are merged with this object.
@@ -773,7 +1176,7 @@ export interface Language<
 	matchesSelectorClass?(
 		className: string,
 		node: Options["Node"],
-		ancestry: Options["Node"][],
+		ancestry: Array<Options["Node"]>,
 	): boolean;
 
 	/**
@@ -876,7 +1279,7 @@ export interface NotOkParseResult {
 	/**
 	 * Any parsing errors, whether fatal or not. (only when ok: false)
 	 */
-	errors: FileError[];
+	errors: Array<FileError>;
 
 	/**
 	 * Any additional data that the parser wants to provide.
@@ -937,7 +1340,7 @@ interface SourceCodeBase<
 	 * When present, this overrides the `visitorKeys` on the language for
 	 * just this source code object.
 	 */
-	visitorKeys?: Record<string, string[]>;
+	visitorKeys?: Record<string, Array<string>>;
 
 	/**
 	 * Retrieves the equivalent of `loc` for a given node or token.
@@ -968,23 +1371,23 @@ interface SourceCodeBase<
 	 * along with any problems found in evaluating the directives.
 	 */
 	getDisableDirectives?(): {
-		directives: Directive[];
-		problems: FileProblem[];
+		directives: Array<Directive>;
+		problems: Array<FileProblem>;
 	};
 
 	/**
 	 * Returns an array of all inline configuration nodes found in the
 	 * source code.
 	 */
-	getInlineConfigNodes?(): Options["ConfigNode"][];
+	getInlineConfigNodes?(): Array<Options["ConfigNode"]>;
 
 	/**
 	 * Applies configuration found inside of the source code. This method is only
 	 * called when ESLint is running with inline configuration allowed.
 	 */
 	applyInlineConfig?(): {
-		configs: InlineConfigElement[];
-		problems: FileProblem[];
+		configs: Array<InlineConfigElement>;
+		problems: Array<FileProblem>;
 	};
 
 	/**
@@ -1046,7 +1449,7 @@ export interface VisitTraversalStep {
 	kind: 1;
 	target: unknown;
 	phase: 1 /* enter */ | 2 /* exit */;
-	args: unknown[];
+	args: Array<unknown>;
 }
 
 /**
@@ -1056,7 +1459,7 @@ export interface CallTraversalStep {
 	kind: 2;
 	target: string;
 	phase?: string;
-	args: unknown[];
+	args: Array<unknown>;
 }
 
 export type TraversalStep = VisitTraversalStep | CallTraversalStep;

--- a/packages/migrate-config/package.json
+++ b/packages/migrate-config/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/eslint/rewrite/tree/main/packages/migrate-config#readme",
   "devDependencies": {
-    "@types/eslint": "^9.6.0",
+    "@eslint/core": "^0.15.1",
     "eslint": "^9.27.0"
   },
   "engines": {

--- a/packages/migrate-config/src/migrate-config.js
+++ b/packages/migrate-config/src/migrate-config.js
@@ -19,9 +19,9 @@ import * as espree from "espree";
 // Types
 //-----------------------------------------------------------------------------
 
-/** @typedef {import("eslint").Linter.FlatConfig} FlatConfig */
-/** @typedef {import("eslint").Linter.LegacyConfig} LegacyConfig  */
-/** @typedef {import("eslint").Linter.ConfigOverride} ConfigOverride  */
+/** @typedef {import("@eslint/core").ConfigObject} FlatConfig */
+/** @typedef {import("@eslint/core").LegacyConfigObject} LegacyConfig  */
+/** @typedef {import("@eslint/core").ConfigOverride} ConfigOverride  */
 /** @typedef {import("recast").types.namedTypes.ObjectExpression} ObjectExpression */
 /** @typedef {import("recast").types.namedTypes.ArrayExpression} ArrayExpression */
 /** @typedef {import("recast").types.namedTypes.CallExpression} CallExpression */


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Copied config-related types over from the `eslint` package into `@eslint/core`

#### What changes did you make? (Give an overview)

* Updated `package.json` files in `packages/compat`, `packages/config-helpers`, and `packages/migrate-config` to move `@eslint/core` to the `dependencies` section, ensuring it is available at runtime. [[1]](diffhunk://#diff-ca4ac111fea0534801dbc2d0b872ca3ceeec61b41feb93a4b7187b6300f047f3R51-L52) [[2]](diffhunk://#diff-c32ce57196448b2990064f6fb5e120cdae8a892732919f43b28100c24ea53639R49-L50) [[3]](diffhunk://#diff-89500919212a00c8e27472714793b07bc082258278e00cab5833faa776ca9a02L42-R42)
* Replaced `eslint` type imports with `@eslint/core` in `packages/compat/src/fixup-rules.js`, `packages/compat/src/ignore-file.js`, `packages/config-helpers/src/define-config.js`, `packages/config-helpers/src/global-ignores.js`, `packages/config-helpers/src/types.ts`, and `packages/migrate-config/src/migrate-config.js`. This includes updates to typedefs like `Config`, `Plugin`, `RuleEntry`, and others to their corresponding `@eslint/core` counterparts. [[1]](diffhunk://#diff-0137961ff6b33330187fc614147a403e39f6c68d95d91b1115f4ca819febb873L10-R13) [[2]](diffhunk://#diff-80cf59be9dbc2a2a459a5d083de62025525f77208a2bd408ca36f02b3b7eb1ffL17-R17) [[3]](diffhunk://#diff-a42aaf8268f1b91836794b8203043694f266efcd4bc078af6091e13481d3d694L10-R13) [[4]](diffhunk://#diff-77c67dee7b326bd6b5123305da94beba242b412f11b50a1b0a2b1372b68f91a3L10-R10) [[5]](diffhunk://#diff-80701ad5d335969fdf91e54ba4c8a6bb688a2efb7ab59b6d8d33af1411151140L5-R29) [[6]](diffhunk://#diff-783de1ed10b8bafd4690e61b68f4b159feb9b84efaf6b4d977c7b319cf2733ddL22-R24)
* Renamed or adjusted type aliases for improved consistency, such as `RuleEntry` to `RuleConfig` and `Linter.Config` to `ConfigObject`. [[1]](diffhunk://#diff-a42aaf8268f1b91836794b8203043694f266efcd4bc078af6091e13481d3d694L156-R156) [[2]](diffhunk://#diff-80701ad5d335969fdf91e54ba4c8a6bb688a2efb7ab59b6d8d33af1411151140L5-R29)
* Updated `@typescript-eslint/array-type` to enforce consistent array type definitions in TypeScript files. The rule is configured to use `generic` for default array types and `array` for readonly arrays.

#### Related Issues

fixes #226

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
