### PR TITLE
fix: potential quadratic runtime in regular expression

### DIFF
--- a/packages/plugin-kit/src/config-comment-parser.js
+++ b/packages/plugin-kit/src/config-comment-parser.js
@@ -155,7 +155,7 @@ export class ConfigCommentParser {
 		 * But we are supporting that. So this is a fallback for that.
 		 */
 		const normalizedString = string
-			.replace(/([-a-zA-Z0-9/]+):/gu, '"$1":')
+			.replace(/(?<![-a-zA-Z0-9/])([-a-zA-Z0-9/]+):/gu, '"$1":')
 			.replace(/(\]|[0-9])\s+(?=")/u, "$1,");
 
 		try {

--- a/packages/plugin-kit/tests/config-comment-parser.test.js
+++ b/packages/plugin-kit/tests/config-comment-parser.test.js
@@ -254,6 +254,11 @@ describe("ConfigCommentParser", () => {
 				},
 			});
 		});
+
+		it("should not timeout for large inputs", () => {
+			const code = `${"A".repeat(100_000)}?: 1 B: 2`;
+			commentParser.parseJSONLikeConfig(code);
+		});
 	});
 
 	describe("parseDirective", () => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Improve regular expressions in this repository that could match with unexpected overhead for certain strings.

#### What changes did you make? (Give an overview)

I improved a regular expression in the plugin-kit package that could match in quadratic runtime for certain strings. I did not find any other regular expressions in the source code of this repository that could have this kind of impact.

#### Related Issues

n/a

#### Is there anything you'd like reviewers to focus on?

no