### PR TITLE
fix: Allow MCP server to fix issues when asked to

### DIFF
--- a/packages/mcp/src/mcp-server.js
+++ b/packages/mcp/src/mcp-server.js
@@ -48,11 +48,11 @@ mcpServer.tool(
 
 		content.unshift({
 			type,
-			text: "Here are the results of running ESLint on the provided files:",
+			text: "Here are the results of running ESLint on the provided files. Before doing anything else, you must display the full list to the user:",
 		});
 		content.push({
 			type,
-			text: "Do not automatically fix these issues. You must ask the user for confirmation before attempting to fix the issues found.",
+			text: "If the user asked to fix any issues found, proceed in fixing them. If the user did not ask to fix issues found, you must ask the user for confirmation before attempting to fix the issues found.",
 		});
 
 		return {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Make it so the MCP server will allow agents to automatically fix lint errors when the user has provided those instructions.

#### What changes did you make? (Give an overview)

- Changed the prompt in the `lint-files` tool to state that the lint issues can be fixed if the user has instruction the agent to do so.
- Also updated the `lint-files` result so that it will always output the lint results regardless if fixes were applied. (By default, it seemed like the agent would not output the full results because it would prioritize fixing the found issues over displaying issues it was fixing.)

#### Related Issues

fixes #246

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
