### PR TITLE
fix: Set proper version for mcp server

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -47,7 +47,6 @@
     },
     "packages/mcp": {
       "release-type": "node",
-      "release-as": "0.1.0",
       "extra-files": ["src/mcp-server.js"]
     },
     "packages/migrate-config": {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

We forgot to remove the `release-as` field from the `mcp` package, meaning release-please can't release a new version because it keeps trying to release the same version.

So, I removed release-as.


#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
