### PR TITLE
ci: pin macOS runner to macOS-14

### DIFF
--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -14,7 +14,7 @@ jobs:
 
         strategy:
             matrix:
-                os: [windows-latest, macOS-latest, ubuntu-latest]
+                os: [windows-latest, macOS-14, ubuntu-latest]
                 bun: [latest]
 
         steps:


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

GitHub Actions has updated `macOS-latest` to point to macOS 15. Our Bun workflow is currently failing on macOS 15, so this PR pins the macOS runner to `macOS-14` to restore CI stability for now.

#### What changes did you make? (Give an overview)

Updated the Bun job matrix to use `macOS-14` instead of `macOS-latest`

#### Related Issues

https://github.com/actions/runner-images/issues/12520

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
