### PR TITLE
fix!: Remove deprecated RuleContext methods

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -304,21 +304,9 @@ export interface RuleContext<
 	cwd: string;
 
 	/**
-	 * Returns the current working directory for the session.
-	 * @deprecated Use `cwd` instead.
-	 */
-	getCwd(): string;
-
-	/**
 	 * The filename of the file being linted.
 	 */
 	filename: string;
-
-	/**
-	 * Returns the filename of the file being linted.
-	 * @deprecated Use `filename` instead.
-	 */
-	getFilename(): string;
 
 	/**
 	 * The physical filename of the file being linted.
@@ -326,21 +314,9 @@ export interface RuleContext<
 	physicalFilename: string;
 
 	/**
-	 * Returns the physical filename of the file being linted.
-	 * @deprecated Use `physicalFilename` instead.
-	 */
-	getPhysicalFilename(): string;
-
-	/**
 	 * The source code object that the rule is running on.
 	 */
 	sourceCode: Options["Code"];
-
-	/**
-	 * Returns the source code object that the rule is running on.
-	 * @deprecated Use `sourceCode` instead.
-	 */
-	getSourceCode(): Options["Code"];
 
 	/**
 	 * Shared settings for the configuration.


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Removed the deprecated methods from `RuleContext`. (Prep for v10)

#### Related Issues

Refs https://github.com/eslint/eslint/pull/20086

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
