### PR TITLE
fix: remove unsupported `nodeType` from types

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -485,12 +485,6 @@ type RuleFixer = (
 
 interface ViolationReportBase {
 	/**
-	 * The type of node that the violation is for.
-	 * @deprecated May be removed in the future.
-	 */
-	nodeType?: string | undefined;
-
-	/**
 	 * The data to insert into the message.
 	 */
 	data?: Record<string, string> | undefined;


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This PR removes `nodeType` from `ViolationReportBase`. `context.report()` doesn’t accept a `nodeType` property—it is ignored.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
