### PR TITLE
ci: workaround for CI failure on Windows with Bun

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lint-staged": "^15.2.0",
     "mocha": "^11.5.0",
     "prettier": "^3.4.1",
-    "rollup": "^4.42.0",
+    "rollup": "4.51.0",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.0.0",
     "yorkie": "^2.0.0"


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## What is the purpose of this pull request?

In this PR, I've fixed CI to work around a failure on Windows with Bun.

Currently, Bun CI on Windows is failing due to the newly released Rollup `4.52.0`. 

As a workaround, I've pinned Rollup to `4.51.0`.

Here are the references:

- Release: https://github.com/rollup/rollup/releases/tag/v4.52.0
- Issue: https://github.com/rollup/rollup/issues/6119
- PR: https://github.com/oven-sh/bun/pull/22816

<img width="1870" height="684" alt="image" src="https://github.com/user-attachments/assets/c9f69834-5a89-4158-94e5-22be2c13ada1" />

https://github.com/eslint/rewrite/actions/runs/17956574548/job/51069303147

## What changes did you make? (Give an overview)

In this PR, I've fixed CI to work around a failure on Windows with Bun.

## Related Issues

Ref: https://github.com/eslint/json/pull/154#discussion_r2368479671

<!-- include tags like "fixes #123" or "refs #123" -->

## Is there anything you'd like reviewers to focus on?

It seems that `rollup` 4.52.2 has been released, but the issue above wasn't included, so I think we need to wait until `rollup` 4.53.0 is released.

https://github.com/rollup/rollup/releases/tag/v4.52.2