### PR TITLE
test: use `strictEqual` in `plugin-kit` where possible

### DIFF
--- a/packages/plugin-kit/tests/source-code.test.js
+++ b/packages/plugin-kit/tests/source-code.test.js
@@ -1752,7 +1752,7 @@ describe("source-code", () => {
 			});
 
 			it("should handle empty text", () => {
-				assert.deepStrictEqual(
+				assert.strictEqual(
 					new TextSourceCodeBase({
 						ast: {
 							loc: {
@@ -1770,7 +1770,7 @@ describe("source-code", () => {
 					}).getIndexFromLoc({ line: 1, column: 0 }),
 					0,
 				);
-				assert.deepStrictEqual(
+				assert.strictEqual(
 					new TextSourceCodeBase({
 						ast: {
 							loc: {
@@ -1788,7 +1788,7 @@ describe("source-code", () => {
 					}).getIndexFromLoc({ line: 0, column: 1 }),
 					0,
 				);
-				assert.deepStrictEqual(
+				assert.strictEqual(
 					new TextSourceCodeBase({
 						ast: {
 							loc: {
@@ -1806,7 +1806,7 @@ describe("source-code", () => {
 					}).getIndexFromLoc({ line: 0, column: 0 }),
 					0,
 				);
-				assert.deepStrictEqual(
+				assert.strictEqual(
 					new TextSourceCodeBase({
 						ast: {
 							loc: {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This PR is follow-up to https://github.com/eslint/css/pull/167#discussion_r2372668738, and https://github.com/eslint/json/pull/109#discussion_r2372609361.

In this PR, I've used `strictEqual` in `plugin-kit` where possible.

#### What changes did you make? (Give an overview)

In this PR, I've used `strictEqual` in `plugin-kit` where possible.

#### Related Issues

Ref: https://github.com/eslint/css/pull/167#discussion_r2372668738, and https://github.com/eslint/json/pull/109#discussion_r2372609361

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

N/A
