### PR TITLE
build: add `@types/node` to `compat` and `mcp`

### DIFF
--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -52,6 +52,7 @@
     "@eslint/core": "^0.16.0"
   },
   "devDependencies": {
+    "@types/node": "^24.7.2",
     "eslint": "^9.27.0"
   },
   "peerDependencies": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -39,5 +39,8 @@
     "@modelcontextprotocol/sdk": "^1.11.0",
     "eslint": "^9.26.0",
     "zod": "^3.24.4"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.2"
   }
 }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This pull request fixes build errors with Bun:

* https://github.com/eslint/rewrite/actions/runs/18438321866/job/52535046075
* https://github.com/eslint/rewrite/actions/runs/18424946095/job/52504870576
* https://github.com/eslint/rewrite/actions/runs/18442441898/job/52544639870

#### What changes did you make? (Give an overview)

Added missing types for Node.js built-ins as devDependencies for `compat` and `mcp`.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

We had another issue with Rollup breaking the build in Bun some weeks ago: #277.

#### Is there anything you'd like reviewers to focus on?
