### PR TITLE
fix: require `fix` in suggestion objects

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -487,7 +487,7 @@ interface ViolationReportBase {
 	/**
 	 * The data to insert into the message.
 	 */
-	data?: Record<string, string> | undefined;
+	data?: Record<string, unknown> | undefined;
 
 	/**
 	 * The fix to be applied for the violation.
@@ -521,12 +521,12 @@ interface SuggestedEditBase {
 	/**
 	 * The data to insert into the message.
 	 */
-	data?: Record<string, string> | undefined;
+	data?: Record<string, unknown> | undefined;
 
 	/**
 	 * The fix to be applied for the suggestion.
 	 */
-	fix?: RuleFixer | null | undefined;
+	fix: RuleFixer;
 }
 
 type SuggestionMessage = { desc: string } | { messageId: string };

--- a/packages/core/tests/types/types.test.ts
+++ b/packages/core/tests/types/types.test.ts
@@ -298,6 +298,7 @@ const testRule: RuleDefinition<{
 							start: { line: node.start, column: 1 },
 							end: { line: node.start + 1, column: Infinity },
 						},
+						data: undefined,
 						fix(fixer: RuleTextEditor): RuleTextEdit {
 							return fixer.replaceText(
 								node,
@@ -318,6 +319,12 @@ const testRule: RuleDefinition<{
 					suggest: [
 						{
 							messageId: "Bar",
+							data: {
+								foo: "foo",
+								bar: 1,
+								baz: true,
+							},
+							// @ts-expect-error -- 'fix' is required in suggestion objects
 							fix: null,
 						},
 					],
@@ -328,6 +335,11 @@ const testRule: RuleDefinition<{
 				context.report({
 					message: "This baz is foobar",
 					loc: { line: node.start, column: 1 },
+					data: {
+						foo: "foo",
+						bar: 1,
+						baz: true,
+					},
 					fix: null,
 					suggest: null,
 				});


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This PR updates TypeScript types for suggestion objects so that the `fix` property is required.

This prevents creating suggestions without a fix, which would otherwise cause the runtime error:
```
TypeError: context.report() called with a suggest option without a fix function.
```

It also broadens the type of `data` from `Record<string, string>` → `Record<string, unknown>` because ESLint message interpolation can accept any value that can be stringified.

#### What changes did you make? (Give an overview)

- Made `fix` required in `SuggestedEditBase`.
- Changed `data` type to `Record<string, unknown>` for compatibility with ESLint message interpolation.
- Added tests for `data` to ensure various types are allowed.
- Added `@ts-expect-error` in test where `fix: null` is used.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
