### PR TITLE
fix: update cli script name for mcp cli

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -3,7 +3,9 @@
   "version": "0.1.1",
   "description": "MCP server for ESLint",
   "type": "module",
-  "bin": "./src/mcp-cli.js",
+  "bin": {
+    "eslint-mcp": "./src/mcp-cli.js"
+  },
   "files": [
     "src"
   ],


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

To fix the name of the mcp server cli script. 

This script
```sh
sample_project="$(mktemp -d)";
(
    cd "${sample_project}" && \
    npm init -y && \
    npm i --save-dev @eslint/mcp@latest && \
    find ./node_modules/.bin -type l -exec ls -l {} \; |\
    grep eslint |\
    grep mcp
);
rm -r "${sample_project}";
```
outputs
`./node_modules/.bin/mcp -> ../@eslint/mcp/src/mcp-cli.js`

#### What changes did you make? (Give an overview)

I updated `bin` in `package.json`.

```sh
npm run build --workspace=@eslint/mcp && \
npm run test --workspace=@eslint/mcp && \
(
    path_to_local_eslint_mcp="$(pwd)/packages/mcp";
    sample_project="$(mktemp -d)";
    (
        cd "${sample_project}" && \
        npm init -y && \
        npm i --save-dev "${path_to_local_eslint_mcp}" && \
        find ./node_modules/.bin -type l -exec ls -l {} \; |\
        grep eslint |\
        grep mcp
    );
    rm -r "${sample_project}";
)
```
builds, passes the tests, and outputs
`./node_modules/.bin/eslint-mcp -> ../@eslint/mcp/src/mcp-cli.js`

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
