### PR TITLE
feat: export additional core types

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -479,11 +479,11 @@ export interface RuleTextEdit {
  * @param fixer The text editor to apply the fix.
  * @returns The fix(es) for the violation.
  */
-type RuleFixer = (
+export type RuleFixer = (
 	fixer: RuleTextEditor,
 ) => RuleTextEdit | Iterable<RuleTextEdit> | null;
 
-interface ViolationReportBase {
+export interface ViolationReportBase {
 	/**
 	 * The data to insert into the message.
 	 */
@@ -501,10 +501,10 @@ interface ViolationReportBase {
 	suggest?: SuggestedEdit[] | null | undefined;
 }
 
-type ViolationMessage<MessageIds = string> =
+export type ViolationMessage<MessageIds = string> =
 	| { message: string }
 	| { messageId: MessageIds };
-type ViolationLocation<Node> =
+export type ViolationLocation<Node> =
 	| { loc: SourceLocation | Position }
 	| { node: Node };
 
@@ -517,7 +517,7 @@ export type ViolationReport<
 
 // #region Suggestions
 
-interface SuggestedEditBase {
+export interface SuggestedEditBase {
 	/**
 	 * The data to insert into the message.
 	 */
@@ -529,7 +529,7 @@ interface SuggestedEditBase {
 	fix: RuleFixer;
 }
 
-type SuggestionMessage = { desc: string } | { messageId: string };
+export type SuggestionMessage = { desc: string } | { messageId: string };
 
 /**
  * A suggested edit for a rule violation.
@@ -539,7 +539,7 @@ export type SuggestedEdit = SuggestedEditBase & SuggestionMessage;
 /**
  * The normalized version of a lint suggestion.
  */
-interface LintSuggestion {
+export interface LintSuggestion {
 	/** A short description. */
 	desc: string;
 
@@ -904,7 +904,7 @@ export type EcmaVersion =
  * The type of JavaScript source code.
  * @deprecated Only supported in legacy eslintrc config format.
  */
-type JavaScriptSourceType = "script" | "module" | "commonjs";
+export type JavaScriptSourceType = "script" | "module" | "commonjs";
 
 /**
  * Parser options.
@@ -974,7 +974,7 @@ export interface EnvironmentConfig {
 /**
  * A configuration object that may have a `rules` block.
  */
-interface HasRules<Rules extends RulesConfig = RulesConfig> {
+export interface HasRules<Rules extends RulesConfig = RulesConfig> {
 	rules?: Partial<Rules> | undefined;
 }
 
@@ -983,7 +983,7 @@ interface HasRules<Rules extends RulesConfig = RulesConfig> {
  *
  * @see [ESLint Legacy Configuration](https://eslint.org/docs/latest/use/configure/)
  */
-interface BaseConfig<
+export interface BaseConfig<
 	Rules extends RulesConfig = RulesConfig,
 	OverrideRules extends RulesConfig = Rules,
 > extends HasRules<Rules> {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Export additional core types to be referenced by ESLint types to avoid duplications.

#### What changes did you make? (Give an overview)

This PR exports types that are either identical to ESLint types, or generics that can be used to declare ESLint types.

| Core type              | ESLint type                        |
|------------------------|------------------------------------|
| `BaseConfig`           | `Linter.BaseConfig`                |
| `HasRules`             | `Linter.HasRules`                  |
| `JavaScriptSourceType` | `Linter.SourceType`                |
| `LintSuggestion`       | `Linter.LintSuggestion`            |
| `RuleConfig` (already exported) | `Linter.RuleEntry`                 |
| `RuleFixer`            | `Rule.ReportFixer`                 |
| `SuggestedEdit` (already exported) | `Rule.SuggestionReportDescriptor`  |
| `SuggestedEditBase`    | `Rule.SuggestionReportOptions`     |
| `SuggestionMessage`    | `Rule.SuggestionDescriptorMessage` |
| `ViolationLocation`    | `Rule.ReportDescriptorLocation`    |
| `ViolationMessage`     | `Rule.ReportDescriptorMessage`     |
| `ViolationReport` (already exported) | `Rule.ReportDescriptor`            |
| `ViolationReportBase`  | `Rule.ReportDescriptorOptions`     |

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

Related to eslint/eslint#20168.

#### Is there anything you'd like reviewers to focus on?

Did I miss something?