### PR TITLE
chore: add `@cfworker/json-schema` to fix CI

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -36,11 +36,12 @@
     "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.11.0",
+    "@modelcontextprotocol/sdk": "^1.21.0",
     "eslint": "^9.26.0",
     "zod": "^3.24.4"
   },
   "devDependencies": {
+    "@cfworker/json-schema": "^4.1.1",
     "@types/node": "^24.7.2"
   }
 }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This pull request fixes CI failures caused by `@modelcontextprotocol/sdk@1.21.0` exporting type definitions that reference `@cfworker/json-schema`. Since that package is only declared as an optional peer dependency in the SDK, it is not installed automatically, which leads to the following TypeScript error:
```
TS2307: Cannot find module '@cfworker/json-schema' or its corresponding type declarations.
```

#### What changes did you make? (Give an overview)

I added `@cfworker/json-schema` to `devDependencies` so the type import can be resolved during the build.

#### Related Issues

https://github.com/eslint/rewrite/actions/runs/19061914344/job/54443304560
https://github.com/eslint/rewrite/actions/runs/19113488111/job/54616379148

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
