### PR TITLE
chore: update test types npm script and CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,9 @@ jobs:
                   npm install
                   npm run build
 
+            - name: Run TypeScript Compiler
+              run: npx tsc
+
             - name: Test types (core)
               working-directory: packages/core
               run: |

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "fmt": "prettier --write .",
     "fmt:check": "prettier --check .",
     "test:jsr": "npm run test:jsr --workspaces --if-present",
-    "test:types": "tsc"
+    "test:types": "tsc && npm run test:types --workspaces --if-present"
   },
   "workspaces": [
     "packages/*"

--- a/packages/migrate-config/src/migrate-config-cli.js
+++ b/packages/migrate-config/src/migrate-config-cli.js
@@ -23,6 +23,7 @@
 import fsp from "node:fs/promises";
 import path from "node:path";
 import { migrateConfig, migrateJSConfig } from "./migrate-config.js";
+// @ts-ignore: No types available
 import { Legacy } from "@eslint/eslintrc";
 
 //-----------------------------------------------------------------------------

--- a/packages/migrate-config/src/migrate-config.js
+++ b/packages/migrate-config/src/migrate-config.js
@@ -8,6 +8,7 @@
 //-----------------------------------------------------------------------------
 
 import * as recast from "recast";
+// @ts-ignore: No types available
 import { Legacy } from "@eslint/eslintrc";
 import camelCase from "camelcase";
 import pluginsNeedingCompat from "./compat-plugins.js";


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

* Fix and update the npm script `test:types`.
* Update "Test Types" CI job.

#### What changes did you make? (Give an overview)

* Updated the npm script `test:types` to run type tests in all packages. This script is only run locally.
* Updated the CI workflow to run `npx tsc` when testing types. This is to catch type problems in packages without type tests.
* Added `@ts-ignore` comments to fix an issue with missing type definitions in `migrate-config`.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
