### PR TITLE
fix!: set core package to v1.0.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -37,6 +37,7 @@
     },
     "packages/core": {
       "release-type": "node",
+      "release-as": "1.0.0",
       "extra-files": [
         {
           "type": "json",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Switch the `@eslint/core` package from a prerelease to release v1.0.0.

#### What changes did you make? (Give an overview)

Updated `release-please-config.json`. The change should be reverted after `@eslint/core` is released.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

https://github.com/eslint/markdown/issues/577#issuecomment-3491671119

#### Is there anything you'd like reviewers to focus on?

If there is a better way to bump the package version, please, let me know.

I think this change isn't strictly necessary for the ESLint v10.0.0-alpha.0 or another prerelease, but it's safe to include.
