### PR TITLE
fix: fix comments removal in includeIgnoreFile()

### DIFF
--- a/packages/compat/src/ignore-file.js
+++ b/packages/compat/src/ignore-file.js
@@ -84,8 +84,13 @@ export function includeIgnoreFile(ignoreFilePath, name) {
 	return {
 		name: name || "Imported .gitignore patterns",
 		ignores: lines
-			.map(line => line.trim())
-			.filter(line => line && !line.startsWith("#"))
+			.map(line =>
+				line
+					.trim()
+					.replace(/\s?[^\\]?#.*/gu, "")
+					.trim(),
+			)
+			.filter(Boolean)
 			.map(convertIgnorePatternToMinimatch),
 	};
 }

--- a/packages/compat/tests/fixtures/ignore-files/gitignore1.txt
+++ b/packages/compat/tests/fixtures/ignore-files/gitignore1.txt
@@ -4,7 +4,7 @@ node_modules
 /dist
 
 # Logs
-*.log
+*.log # End with .log
 
 # Gatsby files
 .cache/


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [ ] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Fix comment removal removal in `includeIgnoreFile()`. Following [`.gitignore` documentation](https://git-scm.com/docs/gitignore).

#### What changes did you make? (Give an overview)

In `.map`, I use regex for removing the valid comment.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->
N/A

#### Is there anything you'd like reviewers to focus on?

N/A
