### PR TITLE
refactor: use `SettingsConfig` type for settings

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -809,7 +809,7 @@ export interface ConfigObject<Rules extends RulesConfig = RulesConfig> {
 	 * An object containing name-value pairs of information that should be
 	 * available to all rules.
 	 */
-	settings?: Record<string, unknown>;
+	settings?: SettingsConfig;
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Update core type definitions.

#### What changes did you make? (Give an overview)

Changed the `settings` property type in `ConfigObject` to `SettingsConfig`.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
