### PR TITLE
ci: ensure the auto-created `release-please` action runs CI

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,6 +6,7 @@ on:
 name: release-please
 
 permissions:
+    contents: read
     id-token: write
 
 jobs:


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## What is the purpose of this pull request?

This PR follows up on https://github.com/eslint/css/pull/330.

In this PR, I've ensured the auto-created `release-please` action triggers CI.

### Problem

Currently, the auto-created PR from the `release-please` action does not trigger CI, as shown below: 

https://github.com/eslint/rewrite/pull/336

<img width="874" height="223" alt="image" src="https://github.com/user-attachments/assets/1bd65ffc-655b-4979-a93b-612347a52a98" />

This can result in CI not running and may lead to issues like https://github.com/eslint/rewrite/issues/308 if the check is missing.

### Solution

I've used `secrets.WORKFLOW_PUSH_BOT_TOKEN` instead of the default `secrets.GITHUB_TOKEN`, following the same approach described in https://github.com/eslint/css/pull/330.

Also, the `permissions` for `contents` and `pull-requests` are no longer necessary because `secrets.WORKFLOW_PUSH_BOT_TOKEN` already grants the required permissions, so I removed it.

FYI: the `token` input reference: https://github.com/googleapis/release-please-action?tab=readme-ov-file#action-inputs

<img width="852" height="135" alt="image" src="https://github.com/user-attachments/assets/4edce632-ae53-483b-be2a-5762dfc9e43e" />

### Test

I've tested it in my forked repository, and it works as expected:

https://github.com/lumirlumir/fork-rewrite/pull/9

- Before: CI wasn't running

<img width="1278" height="984" alt="스크린샷 2025-12-15 191430" src="https://github.com/user-attachments/assets/e2a0c243-0fe1-4ca4-a7eb-439b585024cd" />

- After: CI is running

<img width="1332" height="973" alt="스크린샷 2025-12-15 191842" src="https://github.com/user-attachments/assets/db524ea6-2a86-4d7b-89ab-617c610d017d" />

## What changes did you make? (Give an overview)

This PR follows up on https://github.com/eslint/css/pull/330.

In this PR, I've ensured the auto-created `release-please` action triggers CI.

## Related Issues

Ref: https://github.com/eslint/css/pull/330

<!-- include tags like "fixes #123" or "refs #123" -->

## Is there anything you'd like reviewers to focus on?

N/A