### PR TITLE
fix: remove `experimentalObjectRestSpread` option from types

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -921,7 +921,6 @@ export interface JavaScriptParserOptionsConfig {
 				globalReturn?: boolean | undefined;
 				impliedStrict?: boolean | undefined;
 				jsx?: boolean | undefined;
-				experimentalObjectRestSpread?: boolean | undefined;
 				[key: string]: any;
 		  }
 		| undefined;


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This PR updates the type definitions to remove the `experimentalObjectRestSpread` parser option, which was removed in ESLint [v6.0.0](https://eslint.org/docs/latest/use/migrating-to-6.0.0#-the-deprecated-experimentalobjectrestspread-option-has-been-removed).

#### What changes did you make? (Give an overview)

Removed the `experimentalObjectRestSpread` property from the `JavaScriptParserOptionsConfig` interface

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
