### PR TITLE
docs: replace deprecated rules with non-deprecated counterparts

### DIFF
--- a/packages/config-helpers/README.md
+++ b/packages/config-helpers/README.md
@@ -41,7 +41,7 @@ export default defineConfig([
 		plugins: { js },
 		extends: ["js/recommended"],
 		rules: {
-			semi: "error",
+			"no-var": "error",
 			"prefer-const": "error",
 		},
 	},
@@ -66,7 +66,7 @@ export default defineConfig([
 	{
 		files: ["src/**/*.js"],
 		rules: {
-			semi: "error",
+			"no-var": "error",
 			"prefer-const": "error",
 		},
 	},

--- a/packages/plugin-kit/README.md
+++ b/packages/plugin-kit/README.md
@@ -45,13 +45,13 @@ const commentParser = new ConfigCommentParser();
 
 // pass in a comment string without the comment delimiters
 const directive = commentParser.parseDirective(
-	"eslint-disable prefer-const, semi -- I don't want to use these.",
+	"eslint-disable prefer-const, no-var -- I don't want to use these.",
 );
 
 // will be undefined when a directive can't be parsed
 if (directive) {
 	console.log(directive.label); // "eslint-disable"
-	console.log(directive.value); // "prefer-const, semi"
+	console.log(directive.value); // "prefer-const, no-var"
 	console.log(directive.justification); // "I don't want to use these."
 }
 ```
@@ -65,8 +65,8 @@ import { ConfigCommentParser } from "@eslint/plugin-kit";
 const commentParser = new ConfigCommentParser();
 
 // list format
-const list = commentParser.parseListConfig("prefer-const, semi");
-console.log(Object.entries(list)); // [["prefer-const", true], ["semi", true]]
+const list = commentParser.parseListConfig("prefer-const, no-var");
+console.log(Object.entries(list)); // [["prefer-const", true], ["no-var", true]]
 
 // string format
 const strings = commentParser.parseStringConfig("foo:off, bar");
@@ -74,9 +74,9 @@ console.log(Object.entries(strings)); // [["foo", "off"], ["bar", null]]
 
 // JSON-like config format
 const jsonLike = commentParser.parseJSONLikeConfig(
-	"semi:[error, never], prefer-const: warn",
+	"radix:[error, always], prefer-const: warn",
 );
-console.log(Object.entries(jsonLike.config)); // [["semi", ["error", "never"]], ["prefer-const", "warn"]]
+console.log(Object.entries(jsonLike.config)); // [["radix", ["error", "always"]], ["prefer-const", "warn"]]
 ```
 
 ### `VisitNodeStep` and `CallMethodStep`


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## What is the purpose of this pull request?

In this PR, I've replaced deprecated rules with their non-deprecated counterparts in `README.md`.

The `semi` rule is deprecated and scheduled for removal (like the references below), so if they are removed in the future the documentation example may no longer behave as expected.

- Related Issue: https://github.com/eslint/eslint/issues/20097

https://github.com/eslint/eslint/blob/main/lib/rules/semi.js#L26

<img width="189" height="29" alt="image" src="https://github.com/user-attachments/assets/02616f1c-171a-4cf6-8d13-fce7c7bea862" />

## What changes did you make? (Give an overview)

In this PR, I've replaced deprecated rules with their non-deprecated counterparts in `README.md`.

## Related Issues

N/A

<!-- include tags like "fixes #123" or "refs #123" -->

## Is there anything you'd like reviewers to focus on?

N/A