### PR TITLE
fix: remove `category` property from `RulesMetaDocs` interface

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -120,12 +120,6 @@ export interface RulesMetaDocs {
 	url?: string | undefined;
 
 	/**
-	 * The category the rule falls under.
-	 * @deprecated No longer used.
-	 */
-	category?: string | undefined;
-
-	/**
 	 * Indicates if the rule is generally recommended for all users.
 	 *
 	 * Note - this will always be a boolean for core rules, but may be used in any way by plugins.


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This PR removes the deprecated `category` property from the `RulesMetaDocs` interface. The property was removed from ESLint core in [v8.0.0](https://eslint.org/blog/2021/10/eslint-v8.0.0-released/).

#### What changes did you make? (Give an overview)

Removed the `category` property from the `RulesMetaDocs` interface

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
