### PR TITLE
chore: remove `src/types.ts` from knip entry configuration

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -9,15 +9,11 @@
       "project": ["src/**/*.{cts,js,ts}", "tests/*.{cts,js,ts}"]
     },
     "packages/config-array": {
-      "entry": [
-        "tests/**/*.{cts,js,ts}",
-        "src/types.ts",
-        "rollup.std__path-config.js"
-      ],
+      "entry": ["tests/**/*.{cts,js,ts}", "rollup.std__path-config.js"],
       "project": ["src/**/*.{cts,js,ts}", "tests/**/*.{cts,js,ts}"]
     },
     "packages/config-helpers": {
-      "entry": ["tests/**/*.{cts,js,ts}", "src/types.ts"],
+      "entry": ["tests/**/*.{cts,js,ts}"],
       "project": ["src/**/*.{cts,js,ts}", "tests/**/*.{cts,js,ts}"]
     },
     "packages/core": { "project": ["src/**/*.{cts,js,ts}"] },
@@ -27,19 +23,15 @@
       "project": ["src/**/*.{cts,js,ts}", "tests/**/*.{cts,js,ts}"]
     },
     "packages/migrate-config": {
-      "entry": [
-        "src/migrate-config.js",
-        "src/types.ts",
-        "tests/**/*.{cts,js,ts}"
-      ],
+      "entry": ["src/migrate-config.js", "tests/**/*.{cts,js,ts}"],
       "project": ["src/**/*.{cts,js,ts}", "tests/*.{cts,js,ts}"]
     },
     "packages/object-schema": {
-      "entry": ["tests/**/*.{cts,js,ts}", "src/types.ts"],
+      "entry": ["tests/**/*.{cts,js,ts}"],
       "project": ["src/**/*.{cts,js,ts}", "tests/**/*.{cts,js,ts}"]
     },
     "packages/plugin-kit": {
-      "entry": ["tests/**/*.{cts,js,ts}", "src/types.ts"],
+      "entry": ["tests/**/*.{cts,js,ts}"],
       "project": ["src/**/*.{cts,js,ts}", "tests/**/*.{cts,js,ts}"]
     }
   }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This PR configures knip to properly recognize public API types in `src/types.ts` files so they aren't incorrectly flagged as unused exports. These types are meant for external consumption by package users, even if they're not used internally within our codebase.

#### What changes did you make? (Give an overview)

Added `src/types.ts` to the knip entry configuration for four packages that export public types:
- `@eslint/config-array`
- `@eslint/config-helpers`
- `@eslint/migrate-config`
- `@eslint/plugin-kit`

The `@eslint/object-schema` package already had this configuration.

#### Related Issues

https://github.com/eslint/rewrite/pull/351

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
