### PR TITLE
test: ensure pnpm type support test works when `@eslint/core` is updated

### DIFF
--- a/packages/config-helpers/tests/pnpm/pnpm-workspace.yaml
+++ b/packages/config-helpers/tests/pnpm/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+overrides:
+    # Prevents an ERR_PNPM_NO_MATCHING_VERSION error when @eslint/core is bumped to a yet unpublished version.
+    "@eslint/core": file:../../../core


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Prevent an error in the pnpm type support test of `config-helpers` when `@eslint/core` is updated to a version that hasn't been published to npm yet. This happens when a Release Please PR is updated or merged. Examples in CI:
* https://github.com/eslint/rewrite/actions/runs/20809981279/job/59771734925
* https://github.com/eslint/rewrite/actions/runs/20856061902/job/59922903851

#### What changes did you make? (Give an overview)

Added a `pnpm-worspace.yaml` file in the test directory to override the location of `@eslint/core`. With this configuration, pnpm no longer attempts to install `@eslint/core` in `node_modules`, but `node_modules/.pnpm` is still populated with the files pnpm needs to resolve it. I verified that the pnpm type support test still fails es expected if `tools/dedupe-types.js` is reverted to remove the changes introduced in #289.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
