### PR TITLE
refactor: remove extraneous comments from generated declaration

### DIFF
--- a/packages/plugin-kit/src/source-code.js
+++ b/packages/plugin-kit/src/source-code.js
@@ -19,12 +19,12 @@
 /** @typedef {import("@eslint/core").DirectiveType} DirectiveType */
 /** @typedef {import("@eslint/core").SourceCodeBaseTypeOptions} SourceCodeBaseTypeOptions */
 /**
- * @typedef {import("@eslint/core").TextSourceCode<Options>} TextSourceCode<Options>
+ * @typedef {import("@eslint/core").TextSourceCode<Options>} TextSourceCode
  * @template {SourceCodeBaseTypeOptions} [Options=SourceCodeBaseTypeOptions]
  */
 /** @typedef {import("@eslint/core").RuleVisitor} RuleVisitor */
 /**
- * @typedef {import("./types.ts").CustomRuleVisitorWithExit<RuleVisitorType>} CustomRuleVisitorWithExit<RuleVisitorType>
+ * @typedef {import("./types.ts").CustomRuleVisitorWithExit<RuleVisitorType>} CustomRuleVisitorWithExit
  * @template {RuleVisitor} RuleVisitorType
  */
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

The generated `index.d.ts` contained unnecessary comments before `TextSourceCode` and `CustomRuleVisitorWithExit`:
```ts
/**
 * <Options>
 */
export type TextSourceCode<Options extends SourceCodeBaseTypeOptions = $eslintcore.SourceCodeBaseTypeOptions> = import("@eslint/core").TextSourceCode<Options>;
export type RuleVisitor = $eslintcore.RuleVisitor;
/**
 * <RuleVisitorType>
 */
export type CustomRuleVisitorWithExit<RuleVisitorType extends RuleVisitor> = import("./types.ts").CustomRuleVisitorWithExit<RuleVisitorType>;
```

These comments were caused by including the generic type parameter in the `@typedef` alias name. 

#### What is the purpose of this pull request?

Remove extraneous comments from generated `index.d.ts` file by correcting JSDoc `@typedef` syntax.

#### What changes did you make? (Give an overview)

Removed the redundant generic from the alias names

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
