### PR TITLE
fix: add eslint 10 as peer dependency

### DIFF
--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -57,7 +57,7 @@
     "eslint": "^9.27.0"
   },
   "peerDependencies": {
-    "eslint": "^8.40 || 9"
+    "eslint": "^8.40 || 9 || 10"
   },
   "peerDependenciesMeta": {
     "eslint": {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

`@eslint/compat` supports ESLint v10, but we forgot to include it in `peerDependencies`. Without this, it couldn't be normally installed with ESLint v10.

#### What changes did you make? (Give an overview)

Added 10 to the range.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
