### PR TITLE
fix: export BuiltInMergeStrategy and BuiltInValidationStrategy types

### DIFF
--- a/packages/object-schema/src/object-schema.js
+++ b/packages/object-schema/src/object-schema.js
@@ -13,6 +13,8 @@ import { ValidationStrategy } from "./validation-strategy.js";
 // Types
 //-----------------------------------------------------------------------------
 
+/** @typedef {import("./types.ts").BuiltInMergeStrategy} BuiltInMergeStrategy */
+/** @typedef {import("./types.ts").BuiltInValidationStrategy} BuiltInValidationStrategy */
 /** @typedef {import("./types.ts").ObjectDefinition} ObjectDefinition */
 /** @typedef {import("./types.ts").PropertyDefinition} PropertyDefinition */
 

--- a/packages/object-schema/tests/types/types.test.ts
+++ b/packages/object-schema/tests/types/types.test.ts
@@ -7,4 +7,190 @@
 // Imports
 //-----------------------------------------------------------------------------
 
-import "@eslint/object-schema";
+import {
+	type BuiltInMergeStrategy,
+	type BuiltInValidationStrategy,
+	type ObjectDefinition,
+	ObjectSchema,
+	type PropertyDefinition,
+} from "@eslint/object-schema";
+
+//-----------------------------------------------------------------------------
+// Tests for BuiltInValidationStrategy
+//-----------------------------------------------------------------------------
+
+const validationArray: BuiltInValidationStrategy = "array";
+const validationBoolean: BuiltInValidationStrategy = "boolean";
+const validationNumber: BuiltInValidationStrategy = "number";
+const validationObject: BuiltInValidationStrategy = "object";
+const validationObjectOptional: BuiltInValidationStrategy = "object?";
+const validationString: BuiltInValidationStrategy = "string";
+const validationNonEmptyString: BuiltInValidationStrategy = "string!";
+
+// @ts-expect-error -- Invalid validation strategy
+const invalidValidation: BuiltInValidationStrategy = "invalid";
+
+//-----------------------------------------------------------------------------
+// Tests for BuiltInMergeStrategy
+//-----------------------------------------------------------------------------
+
+const mergeAssign: BuiltInMergeStrategy = "assign";
+const mergeOverwrite: BuiltInMergeStrategy = "overwrite";
+const mergeReplace: BuiltInMergeStrategy = "replace";
+
+// @ts-expect-error -- Invalid merge strategy
+const invalidMerge: BuiltInMergeStrategy = "invalid";
+
+//-----------------------------------------------------------------------------
+// Tests for PropertyDefinition
+//-----------------------------------------------------------------------------
+
+// PropertyDefinition with built-in strategies
+const propertyWithBuiltInStrategies: PropertyDefinition = {
+	required: true,
+	merge: "replace",
+	validate: "string",
+};
+
+propertyWithBuiltInStrategies.required satisfies boolean;
+propertyWithBuiltInStrategies.merge satisfies
+	| BuiltInMergeStrategy
+	| ((target: any, source: any) => any);
+propertyWithBuiltInStrategies.validate satisfies
+	| BuiltInValidationStrategy
+	| ((value: any) => void);
+
+// PropertyDefinition with custom functions
+const propertyWithCustomFunctions: PropertyDefinition = {
+	required: false,
+	merge(target, source) {
+		return source ?? target;
+	},
+	validate(value) {
+		if (typeof value !== "string") {
+			throw new TypeError("Expected a string.");
+		}
+	},
+};
+
+// PropertyDefinition with requires
+const propertyWithRequires: PropertyDefinition = {
+	required: false,
+	requires: ["otherKey1", "otherKey2"],
+	merge: "overwrite",
+	validate: "object",
+};
+
+propertyWithRequires.requires satisfies string[];
+
+// PropertyDefinition with subschema
+const propertyWithSchema: PropertyDefinition = {
+	required: false,
+	merge: "assign",
+	validate: "object",
+	schema: {
+		nestedKey: {
+			required: true,
+			merge: "replace",
+			validate: "string",
+		},
+	},
+};
+
+propertyWithSchema.schema satisfies ObjectDefinition;
+
+//-----------------------------------------------------------------------------
+// Tests for ObjectDefinition
+//-----------------------------------------------------------------------------
+
+const emptyDefinition: ObjectDefinition = {};
+
+const objectDefinition: ObjectDefinition = {
+	name: {
+		required: true,
+		merge: "replace",
+		validate: "string!",
+	},
+	count: {
+		required: false,
+		merge: "overwrite",
+		validate: "number",
+	},
+	options: {
+		required: false,
+		merge: "assign",
+		validate: "object?",
+		schema: {
+			enabled: {
+				required: false,
+				merge: "replace",
+				validate: "boolean",
+			},
+		},
+	},
+};
+
+objectDefinition satisfies Record<string, PropertyDefinition>;
+
+//-----------------------------------------------------------------------------
+// Tests for ObjectSchema class
+//-----------------------------------------------------------------------------
+
+const schema = new ObjectSchema({
+	name: {
+		required: true,
+		merge: "replace",
+		validate: "string",
+	},
+	values: {
+		required: false,
+		merge: "assign",
+		validate: "array",
+	},
+});
+
+schema.hasKey("name") satisfies boolean;
+schema.hasKey("nonexistent") satisfies boolean;
+
+schema.merge(
+	{ name: "first", values: [1, 2] },
+	{ name: "second", values: [3, 4] },
+);
+
+schema.validate({ name: "test" });
+
+// ObjectSchema with custom merge/validate functions
+const schemaWithFunctions = new ObjectSchema({
+	customProp: {
+		required: false,
+		merge(target, source) {
+			return { ...target, ...source };
+		},
+		validate(value) {
+			if (!value || typeof value !== "object") {
+				throw new TypeError("Expected an object.");
+			}
+		},
+	},
+});
+
+// ObjectSchema with subschema
+const schemaWithSubschema = new ObjectSchema({
+	config: {
+		required: true,
+		merge: "assign",
+		validate: "object",
+		schema: {
+			setting1: {
+				required: true,
+				merge: "replace",
+				validate: "string",
+			},
+			setting2: {
+				required: false,
+				merge: "replace",
+				validate: "number",
+			},
+		},
+	},
+});


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This PR exports `BuiltInMergeStrategy` and `BuiltInValidationStrategy` types from `@eslint/object-schema` and adds type tests for the package.

#### What changes did you make? (Give an overview)

- Added `@typedef` imports for  `BuiltInMergeStrategy` and `BuiltInValidationStrategy` so they are included in the generated type declarations.
- Added type tests for the package.

#### Related Issues

Fixes #350

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
