### PR TITLE
chore: remove obsolete @ts-ignore for basePath in config-helpers

### DIFF
--- a/packages/config-helpers/src/define-config.js
+++ b/packages/config-helpers/src/define-config.js
@@ -385,9 +385,7 @@ function extendConfig(baseConfig, baseConfigName, extension, extensionName) {
 
 	result.name = `${baseConfigName} > ${extensionName}`;
 
-	// @ts-ignore -- ESLint types aren't updated yet
 	if (baseConfig.basePath) {
-		// @ts-ignore -- ESLint types aren't updated yet
 		result.basePath = baseConfig.basePath;
 	}
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

This PR removes unnecessary TypeScript ignore directives in `@eslint/config-helpers` now that `@eslint/core`’s `ConfigObject` includes `basePath`.

#### What changes did you make? (Give an overview)

Removed two obsolete `// @ts-ignore` comments around `baseConfig.basePath` / `result.basePath` in `extendConfig()`.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
