### PR TITLE
fix: update dependency minimatch to ^10.2.4

### DIFF
--- a/packages/config-array/package.json
+++ b/packages/config-array/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@eslint/object-schema": "^3.0.2",
     "debug": "^4.3.1",
-    "minimatch": "^10.2.1"
+    "minimatch": "^10.2.4"
   },
   "devDependencies": {
     "@jsr/std__path": "^1.0.4",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

Updates `minimatch` to ^10.2.4 in order to ensure v10.2.3 is skipped because it has a bug that affects ESLint (https://github.com/isaacs/minimatch/issues/284). 

#### What changes did you make? (Give an overview)

Updated package.json of `@eslint/config-array`.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
