### PR TITLE
fix: correct extraConfigTypes validation error messages

### DIFF
--- a/packages/config-array/src/config-array.js
+++ b/packages/config-array/src/config-array.js
@@ -633,14 +633,14 @@ function assertNormalized(configArray) {
 function assertExtraConfigTypes(extraConfigTypes) {
 	if (extraConfigTypes.length > 2) {
 		throw new TypeError(
-			"configTypes must be an array with at most two items.",
+			"extraConfigTypes must be an array with at most two items.",
 		);
 	}
 
 	for (const configType of extraConfigTypes) {
 		if (!CONFIG_TYPES.has(configType)) {
 			throw new TypeError(
-				`Unexpected config type "${configType}" found. Expected one of: "object", "array", "function".`,
+				`Unexpected config type "${configType}" in extraConfigTypes. Expected one of: "array", "function".`,
 			);
 		}
 	}


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

This PR fixes confusing `extraConfigTypes` validation errors so they reference the correct option name and only list supported values.

#### What changes did you make? (Give an overview)

- Refer to `extraConfigTypes` (not `configTypes`) in the “at most two items” error.
- Remove the incorrect `"object"` from the invalid-value error and only list `"array"` / `"function"` as supported values.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
