### PR TITLE
fix: improve `extraConfigTypes` validation

### DIFF
--- a/packages/config-array/src/config-array.js
+++ b/packages/config-array/src/config-array.js
@@ -631,10 +631,12 @@ function assertNormalized(configArray) {
  * @throws {TypeError} When the config types array is invalid.
  */
 function assertExtraConfigTypes(extraConfigTypes) {
+	if (!Array.isArray(extraConfigTypes)) {
+		throw new TypeError("extraConfigTypes must be an array.");
+	}
+
 	if (extraConfigTypes.length > 2) {
-		throw new TypeError(
-			"extraConfigTypes must be an array with at most two items.",
-		);
+		throw new TypeError("extraConfigTypes must contain at most two items.");
 	}
 
 	for (const configType of extraConfigTypes) {

--- a/packages/config-array/tests/config-array.test.js
+++ b/packages/config-array/tests/config-array.test.js
@@ -535,6 +535,52 @@ describe("ConfigArray", () => {
 				},
 			);
 		});
+
+		it("should throw an error when extraConfigTypes is not an array", () => {
+			assert.throws(
+				() => {
+					void new ConfigArray([], {
+						basePath,
+						extraConfigTypes: "array",
+					});
+				},
+				{
+					constructor: TypeError,
+					message: "extraConfigTypes must be an array.",
+				},
+			);
+		});
+
+		it("should throw an error when extraConfigTypes has more than two items", () => {
+			assert.throws(
+				() => {
+					void new ConfigArray([], {
+						basePath,
+						extraConfigTypes: ["array", "function", "array"],
+					});
+				},
+				{
+					constructor: TypeError,
+					message: "extraConfigTypes must contain at most two items.",
+				},
+			);
+		});
+
+		it("should throw an error when extraConfigTypes contains an invalid item", () => {
+			assert.throws(
+				() => {
+					void new ConfigArray([], {
+						basePath,
+						extraConfigTypes: ["array", "object"],
+					});
+				},
+				{
+					constructor: TypeError,
+					message:
+						'Unexpected config type "object" in extraConfigTypes. Expected one of: "array", "function".',
+				},
+			);
+		});
 	});
 
 	describe("Config Pattern Normalization", () => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

Previously, passing a non-array `extraConfigTypes` could throw inconsistent/cryptic runtime errors depending on the value, instead of a clear validation error. For example:

- `extraConfigTypes: null` → `TypeError: Cannot read properties of null (reading 'length')`
- `extraConfigTypes: 1` → `TypeError: extraConfigTypes is not iterable`
- `extraConfigTypes: "array"` → `TypeError: extraConfigTypes must be an array with at most two items.`

This change adds an explicit `Array.isArray()` check so all non-array inputs consistently throw `TypeError: extraConfigTypes must be an array.`

#### What changes did you make? (Give an overview)

- Added an `Array.isArray()` check in `assertExtraConfigTypes()`.
- Tweaked the “too many items” message to `extraConfigTypes must contain at most two items.`.
- Added unit tests.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
