### PR TITLE
refactor: remove redundant await in config-array normalize

### DIFF
--- a/packages/config-array/src/config-array.js
+++ b/packages/config-array/src/config-array.js
@@ -399,7 +399,7 @@ async function normalize(
 	 * Async iterables cannot be used with the spread operator, so we need to manually
 	 * create the array to return.
 	 */
-	const asyncIterable = await flatTraverse(items);
+	const asyncIterable = flatTraverse(items);
 	const configs = [];
 
 	for await (const config of asyncIterable) {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

`flatTraverse` is an `async function*`, so `flatTraverse(items)` returns an async iterable immediately; awaiting it is a no-op.

#### What changes did you make? (Give an overview)

- Removed redundant `await` when calling the async generator `flatTraverse()` inside `normalize()`.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
