### PR TITLE
fix: type-check suggestion messageId against MessageIds

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -449,7 +449,7 @@ export type MessagePlaceholderData = Record<
 	string | number | boolean | bigint | null | undefined
 >;
 
-export interface ViolationReportBase {
+export interface ViolationReportBase<MessageIds extends string = string> {
 	/**
 	 * The data to insert into the message.
 	 */
@@ -464,10 +464,10 @@ export interface ViolationReportBase {
 	 * An array of suggested fixes for the problem. These fixes may change the
 	 * behavior of the code, so they are not applied automatically.
 	 */
-	suggest?: SuggestedEdit[] | null | undefined;
+	suggest?: SuggestedEdit<MessageIds>[] | null | undefined;
 }
 
-export type ViolationMessage<MessageIds = string> =
+export type ViolationMessage<MessageIds extends string = string> =
 	| { message: string }
 	| { messageId: MessageIds };
 export type ViolationLocation<Node> =
@@ -476,8 +476,8 @@ export type ViolationLocation<Node> =
 
 export type ViolationReport<
 	Node = unknown,
-	MessageIds = string,
-> = ViolationReportBase &
+	MessageIds extends string = string,
+> = ViolationReportBase<MessageIds> &
 	ViolationMessage<MessageIds> &
 	ViolationLocation<Node>;
 
@@ -495,12 +495,15 @@ export interface SuggestedEditBase {
 	fix: RuleFixer;
 }
 
-export type SuggestionMessage = { desc: string } | { messageId: string };
+export type SuggestionMessage<MessageIds extends string = string> =
+	| { desc: string }
+	| { messageId: MessageIds };
 
 /**
  * A suggested edit for a rule violation.
  */
-export type SuggestedEdit = SuggestedEditBase & SuggestionMessage;
+export type SuggestedEdit<MessageIds extends string = string> =
+	SuggestedEditBase & SuggestionMessage<MessageIds>;
 
 /**
  * The normalized version of a lint suggestion.

--- a/packages/core/tests/types/types.test.ts
+++ b/packages/core/tests/types/types.test.ts
@@ -315,7 +315,7 @@ const testRule: RuleDefinition<{
 					node,
 					suggest: [
 						{
-							messageId: "Bar",
+							messageId: "wrongBar",
 							data: {
 								foo: "foo",
 								bar: 1,
@@ -345,6 +345,19 @@ const testRule: RuleDefinition<{
 							},
 							// @ts-expect-error -- 'fix' is required in suggestion objects
 							fix: null,
+						},
+						{
+							messageId: "badFoo",
+							fix(fixer) {
+								return fixer.insertTextAfter(node, "badFoo");
+							},
+						},
+						{
+							// @ts-expect-error -- suggestion messageId must be a valid MessageId
+							messageId: "Bar",
+							fix(fixer) {
+								return fixer.insertTextAfter(node, "Bar");
+							},
 						},
 					],
 				});


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

This PR fixes a typing gap in `@eslint/core` where `context.report({ suggest: [...] })` did not type-check `suggest[].messageId` against the rule’s `MessageIds` (so invalid IDs could slip through).

#### What changes did you make? (Give an overview)

- Thread `MessageIds` through `ViolationReportBase`, `SuggestionMessage`, and `SuggestedEdit`.
- Update type tests to cover valid/invalid suggestion `messageId` values.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
