### PR TITLE
build: Allow releases from other branches

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -55,6 +55,7 @@ jobs:
               if: ${{ steps.release.outputs.releases_created == 'true' }}
               env:
                   STEPS_RELEASE_OUTPUTS: ${{ toJson(steps.release.outputs) }}
+                  GITHUB_REF_NAME: ${{ github.ref_name }}
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   TWITTER_API_CONSUMER_KEY: ${{ secrets.TWITTER_CONSUMER_KEY }}
                   TWITTER_API_CONSUMER_SECRET: ${{ secrets.TWITTER_CONSUMER_SECRET }}

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -118,7 +118,13 @@ function publishPackagesToNpm(packageDirs, dependencies) {
 
 		console.log(`Publishing ${packageDir}...`);
 		try {
-			exec(`npm publish -w ${packageDir} --provenance`, {
+			const tag =
+				process.env.GITHUB_REF_NAME &&
+				process.env.GITHUB_REF_NAME !== "main"
+					? "--tag maintenance"
+					: "";
+
+			exec(`npm publish -w ${packageDir} --provenance ${tag}`, {
 				stdio: "inherit",
 				env: process.env,
 			});


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

Allows releases from branches in this format:

```
release/<package-name>/v<version>
```
So to release off of `@eslint/config-array@0.20`, we could create a branch called `release/config-array/v0.20` and then send pull requests to it.

#### What changes did you make? (Give an overview)

Updated the `release-please.yml` file to also target release branches.

#### Related Issues

fixes #378

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
