### PR TITLE
refactor: use lowercase boolean in validation errors

### DIFF
--- a/packages/object-schema/src/validation-strategy.js
+++ b/packages/object-schema/src/validation-strategy.js
@@ -30,7 +30,7 @@ export class ValidationStrategy {
 	 */
 	static boolean(value) {
 		if (typeof value !== "boolean") {
-			throw new TypeError("Expected a Boolean.");
+			throw new TypeError("Expected a boolean.");
 		}
 	}
 

--- a/packages/object-schema/tests/validation-strategy.test.js
+++ b/packages/object-schema/tests/validation-strategy.test.js
@@ -22,25 +22,25 @@ describe("ValidationStrategy", () => {
 		it("should throw an error when the value is null", () => {
 			assert.throws(() => {
 				ValidationStrategy.boolean(null);
-			}, /Expected a Boolean/u);
+			}, /Expected a boolean/u);
 		});
 
 		it("should throw an error when the value is a string", () => {
 			assert.throws(() => {
 				ValidationStrategy.boolean("foo");
-			}, /Expected a Boolean/u);
+			}, /Expected a boolean/u);
 		});
 
 		it("should throw an error when the value is a number", () => {
 			assert.throws(() => {
 				ValidationStrategy.boolean(123);
-			}, /Expected a Boolean/u);
+			}, /Expected a boolean/u);
 		});
 
 		it("should throw an error when the value is an object", () => {
 			assert.throws(() => {
 				ValidationStrategy.boolean({});
-			}, /Expected a Boolean/u);
+			}, /Expected a boolean/u);
 		});
 	});
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

This PR makes the boolean validator naming consistent with the other built-in validators by using lowercase in its error message.

#### What changes did you make? (Give an overview)

Updated the `object-schema` boolean validation error from `Expected a Boolean.` to `Expected a boolean.` and adjusted the related tests to match the new wording.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
