### PR TITLE
fix: avoid mutating object schema definitions during construction

### DIFF
--- a/packages/object-schema/src/object-schema.js
+++ b/packages/object-schema/src/object-schema.js
@@ -167,13 +167,17 @@ export class ObjectSchema {
 
 		// add in all strategies
 		for (const key of Object.keys(definitions)) {
-			validateDefinition(key, definitions[key]);
+			const definition = definitions[key];
+
+			validateDefinition(key, definition);
+
+			let normalizedDefinition = definition;
 
 			// normalize merge and validate methods if subschema is present
-			if (typeof definitions[key].schema === "object") {
-				const schema = new ObjectSchema(definitions[key].schema);
-				definitions[key] = {
-					...definitions[key],
+			if (typeof normalizedDefinition.schema === "object") {
+				const schema = new ObjectSchema(normalizedDefinition.schema);
+				normalizedDefinition = {
+					...normalizedDefinition,
 					merge(first = {}, second = {}) {
 						return schema.merge(first, second);
 					},
@@ -185,30 +189,25 @@ export class ObjectSchema {
 			}
 
 			// normalize the merge method in case there's a string
-			if (typeof definitions[key].merge === "string") {
-				definitions[key] = {
-					...definitions[key],
-					merge: MergeStrategy[
-						/** @type {string} */ (definitions[key].merge)
-					],
+			if (typeof normalizedDefinition.merge === "string") {
+				normalizedDefinition = {
+					...normalizedDefinition,
+					merge: MergeStrategy[normalizedDefinition.merge],
 				};
 			}
 
 			// normalize the validate method in case there's a string
-			if (typeof definitions[key].validate === "string") {
-				definitions[key] = {
-					...definitions[key],
-					validate:
-						ValidationStrategy[
-							/** @type {string} */ (definitions[key].validate)
-						],
+			if (typeof normalizedDefinition.validate === "string") {
+				normalizedDefinition = {
+					...normalizedDefinition,
+					validate: ValidationStrategy[normalizedDefinition.validate],
 				};
 			}
 
-			this.#definitions.set(key, definitions[key]);
+			this.#definitions.set(key, normalizedDefinition);
 
-			if (definitions[key].required) {
-				this.#requiredKeys.set(key, definitions[key]);
+			if (normalizedDefinition.required) {
+				this.#requiredKeys.set(key, normalizedDefinition);
 			}
 		}
 	}

--- a/packages/object-schema/tests/object-schema.test.js
+++ b/packages/object-schema/tests/object-schema.test.js
@@ -28,6 +28,32 @@ describe("ObjectSchema", () => {
 			assert.strictEqual(schema.hasKey("foo"), true);
 		});
 
+		it("should not modify the original definitions object", () => {
+			const definitions = {
+				foo: {
+					merge: "replace",
+					validate: "string",
+				},
+				bar: {
+					schema: {
+						baz: {
+							merge: "replace",
+							validate: "number",
+						},
+					},
+				},
+			};
+
+			schema = new ObjectSchema(definitions);
+
+			assert.strictEqual(definitions.foo.merge, "replace");
+			assert.strictEqual(definitions.foo.validate, "string");
+			assert.strictEqual(definitions.bar.merge, undefined);
+			assert.strictEqual(definitions.bar.validate, undefined);
+			assert.strictEqual(definitions.bar.schema.baz.merge, "replace");
+			assert.strictEqual(definitions.bar.schema.baz.validate, "number");
+		});
+
 		it("should throw an error when a strategy is missing a merge() method", () => {
 			assert.throws(() => {
 				schema = new ObjectSchema({


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [X] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What did you do?

Constructed an `ObjectSchema` from a definitions object and then checked the original object afterward.

```js
const definitions = {
	foo: {
		merge: "replace",
		validate: "string",
	},
};

new ObjectSchema(definitions);
```

#### What did you expect to happen?

The original definitions object should remain unchanged.

```js
definitions.foo.merge === "replace";
definitions.foo.validate === "string";
```

#### What actually happened?

The constructor normalized the definitions in place and replaced the original string values with functions.

#### What is the purpose of this pull request?

This PR prevents `ObjectSchema` from mutating caller-provided schema definitions during construction.

#### What changes did you make? (Give an overview)

- Updated the constructor to normalize each definition into a local value instead of assigning normalized handlers back onto the input `definitions` object.
- Added a regression test.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
