### PR TITLE
fix: reject arrays in ValidationStrategy.object

### DIFF
--- a/packages/object-schema/src/validation-strategy.js
+++ b/packages/object-schema/src/validation-strategy.js
@@ -53,7 +53,7 @@ export class ValidationStrategy {
 	 * @throws {TypeError} If the value is invalid.
 	 */
 	static object(value) {
-		if (!value || typeof value !== "object") {
+		if (!value || typeof value !== "object" || Array.isArray(value)) {
 			throw new TypeError("Expected an object.");
 		}
 	}

--- a/packages/object-schema/tests/validation-strategy.test.js
+++ b/packages/object-schema/tests/validation-strategy.test.js
@@ -90,6 +90,12 @@ describe("ValidationStrategy", () => {
 				ValidationStrategy.object("");
 			}, /Expected an object/u);
 		});
+
+		it("should throw an error when the value is an array", () => {
+			assert.throws(() => {
+				ValidationStrategy.object([]);
+			}, /Expected an object/u);
+		});
 	});
 
 	describe("array", () => {


### PR DESCRIPTION
Fixes #404

ValidationStrategy.object currently accepts arrays because they are objects in JS. This adds an explicit array guard so object() only accepts plain object values, matching the expected separation from array().

Also added a regression test for ValidationStrategy.object([]).

Greetings, saschabuehrle