### PR TITLE
fix: type-check defaultLanguageOptions against LangOptions

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1175,7 +1175,7 @@ export interface Language<
 	/**
 	 * Default language options. User-defined options are merged with this object.
 	 */
-	defaultLanguageOptions?: LanguageOptions;
+	defaultLanguageOptions?: Options["LangOptions"];
 
 	/**
 	 * Validates languageOptions for this language.

--- a/packages/core/tests/types/types.test.ts
+++ b/packages/core/tests/types/types.test.ts
@@ -210,6 +210,55 @@ const testLanguage: Language = {
 
 testLanguage.defaultLanguageOptions satisfies LanguageOptions | undefined;
 
+const testLanguage2: Language<{
+	LangOptions: {
+		howMuch: boolean;
+		howMany: number;
+	};
+	Code: TestSourceCode;
+	RootNode: TestRootNode;
+	Node: TestNode;
+}> = {
+	fileType: "text",
+	lineStart: 1,
+	columnStart: 1,
+	nodeTypeKey: "type",
+	defaultLanguageOptions: {
+		howMuch: true,
+		// @ts-expect-error -- defaultLanguageOptions must match the language options.
+		howMany: "a lot",
+	},
+
+	validateLanguageOptions(languageOptions) {
+		languageOptions.howMuch satisfies boolean;
+		languageOptions.howMany satisfies number;
+	},
+
+	parse(file, context): ParseResult<TestRootNode> {
+		context.languageOptions.howMuch satisfies boolean;
+		context.languageOptions.howMany satisfies number;
+
+		return {
+			ok: true,
+			ast: {
+				type: "root",
+				start: 0,
+				length: file.body.length,
+			},
+		};
+	},
+
+	createSourceCode(file, input, context): TestSourceCode {
+		context.languageOptions.howMuch satisfies boolean;
+		context.languageOptions.howMany satisfies number;
+		return new TestSourceCode(String(file.body), input.ast);
+	},
+};
+
+testLanguage2.defaultLanguageOptions satisfies
+	| { howMuch: boolean; howMany: number }
+	| undefined;
+
 //-----------------------------------------------------------------------------
 // Tests for rule-related types
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

This PR ensures `Language.defaultLanguageOptions` is type-checked against a language’s `LangOptions` type instead of the broad `LanguageOptions` base type.

#### What changes did you make? (Give an overview)

- Updated the `Language` type in `@eslint/core` so `defaultLanguageOptions` uses `Options["LangOptions"]`.
- Added a type test.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
