### PR TITLE
feat: add `languages` and `docs.dialects` to rule `meta` types

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -130,6 +130,13 @@ export interface RulesMetaDocs {
 	 * Indicates if the rule is frozen (no longer accepting feature requests).
 	 */
 	frozen?: boolean | undefined;
+
+	/**
+	 * The dialects of the languages that the rule is intended to lint.
+	 * @example
+	 * ["JavaScript", "TypeScript"]
+	 */
+	dialects?: string[] | undefined;
 }
 
 /**
@@ -188,11 +195,13 @@ export interface RulesMeta<
 
 	/**
 	 * The language the rule is intended to lint.
+	 * @deprecated Use `languages` instead.
 	 */
 	language?: string;
 
 	/**
 	 * The dialects of `language` that the rule is intended to lint.
+	 * @deprecated Use `docs.dialects` instead.
 	 */
 	dialects?: string[];
 

--- a/packages/core/tests/types/types.test.ts
+++ b/packages/core/tests/types/types.test.ts
@@ -291,6 +291,7 @@ const testRule: RuleDefinition<{
 		fixable: "code",
 		docs: {
 			recommended: true,
+			dialects: ["JavaScript", "TypeScript"],
 		},
 		deprecated: {
 			message: "use something else",

--- a/packages/plugin-kit/tests/types/types.test.ts
+++ b/packages/plugin-kit/tests/types/types.test.ts
@@ -224,6 +224,7 @@ const testRule: TestRuleDefinition<{
 		fixable: "code",
 		docs: {
 			recommended: true,
+			dialects: ["JavaScript", "TypeScript"],
 			foo: true,
 			// @ts-expect-error -- bar should be number, not string
 			bar: "1",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [X] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

Update the core types.

#### What changes did you make? (Give an overview)

This PR adds the `languages` property to the `RulesMeta` interface (the type used for rule `meta` objects), and `dialects` to `RulesMetaDocs` (the `meta.docs` type), following the design described in the [rule languages RFC](https://github.com/eslint/rfcs/blob/main/designs/2025-rule-languages/README.md). The related change in ESLint has already been merged in eslint/eslint#20571. It also deprecates `language` and `dialects` in `RulesMeta`.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

refs eslint/eslint#19462

#### Is there anything you'd like reviewers to focus on?
