### PR TITLE
fix: update `espree` to the latest

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,9 +3,9 @@
 	extends: ["github>eslint/workflows//.github/renovate/eslint-base.json5"],
 	packageRules: [
 		{
-			description: "Update `eslint` in dependencies",
+			description: "Update `eslint` and `espree` in dependencies",
 			matchDepTypes: ["dependencies"],
-			matchPackageNames: ["eslint"],
+			matchPackageNames: ["eslint", "espree"],
 			minimumReleaseAge: null, // Don't wait for these packages
 			rangeStrategy: "bump",
 		},

--- a/packages/migrate-config/package.json
+++ b/packages/migrate-config/package.json
@@ -50,7 +50,7 @@
     "@eslint/compat": "^2.0.5",
     "@eslint/eslintrc": "^3.3.5",
     "camelcase": "^8.0.0",
-    "espree": "^10.4.0",
+    "espree": "^11.2.0",
     "recast": "^0.23.7"
   }
 }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

## What is the purpose of this pull request?

This PR updates `espree` to the latest version and updates the Renovate configuration to automatically keep this dependency up to date, since it’s part of the ESLint package.

Previously, automatic updates were missing, so this package remained on an older version.

The upgrade from `espree` v10 to v11 appears to have no notable downsides.

Release: https://github.com/eslint/js/releases/tag/espree-v11.0.0

## What changes did you make? (Give an overview)

This PR updates `espree` to the latest version and updates the Renovate configuration to automatically keep this dependency up to date, since it’s part of the `eslint` package.

## Related Issues

N/A

<!-- include tags like "fixes #123" or "refs #123" -->

## Is there anything you'd like reviewers to focus on?

N/A