### PR TITLE
ci: add type tests for TypeScript 5.x to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,11 +90,11 @@ jobs:
             - name: Test types (plugin-kit)
               run: npm run test:types -w packages/plugin-kit
 
-            - name: Install TypeScript 5.3.2
-              run: npm install --no-save typescript@5.3.2
+            - name: Check dist types compile (TypeScript 5.3)
+              run: npm run test:types:5.3
 
-            - name: Check dist types compile (TypeScript 5.3.2)
-              run: npx tsc -p tsconfig.dist.json
+            - name: Check dist types compile (TypeScript 5.x)
+              run: npm run test:types:5.x
 
     are-the-types-wrong:
         name: Are the types wrong?

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "test": "npm test --workspaces --if-present",
     "test:jsr": "npm run test:jsr --workspaces --if-present",
     "test:types": "tsc && npm run test:types --workspaces --if-present",
+    "test:types:5.3": "npx -p typescript@5.3 -y -- tsc -p tsconfig.dist-legacy.json",
+    "test:types:5.x": "npx -p typescript@5.x -y -- tsc -p tsconfig.dist.json",
+    "test:types:all": "npm run test:types && npm run test:types:5.x && npm run test:types:5.3",
     "test:unit": "npm run test:unit --workspaces --if-present"
   },
   "workspaces": [

--- a/packages/config-array/tests/types/tsconfig.json
+++ b/packages/config-array/tests/types/tsconfig.json
@@ -1,15 +1,7 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../../../tsconfig.dist.json",
   "compilerOptions": {
-    "allowJs": false,
-    "checkJs": false,
-    "noEmit": true,
-    "rootDir": "../..",
-    "strict": true,
-    "exactOptionalPropertyTypes": true,
-    "verbatimModuleSyntax": true,
-    "erasableSyntaxOnly": true
+    "rootDir": "../.."
   },
-  "files": [],
   "include": [".", "../../dist"]
 }

--- a/packages/config-array/tests/types/tsconfig.json
+++ b/packages/config-array/tests/types/tsconfig.json
@@ -1,8 +1,15 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "allowJs": false,
+    "checkJs": false,
     "noEmit": true,
-    "rootDir": "../.."
+    "rootDir": "../..",
+    "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true
   },
+  "files": [],
   "include": [".", "../../dist"]
 }

--- a/packages/config-helpers/tests/types/tsconfig.json
+++ b/packages/config-helpers/tests/types/tsconfig.json
@@ -1,10 +1,14 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "allowJs": false,
+    "checkJs": false,
     "noEmit": true,
     "rootDir": "../..",
-    "strict": true,
-    "exactOptionalPropertyTypes": true
+    "exactOptionalPropertyTypes": true,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true
   },
+  "files": [],
   "include": [".", "../../dist"]
 }

--- a/packages/config-helpers/tests/types/tsconfig.json
+++ b/packages/config-helpers/tests/types/tsconfig.json
@@ -1,14 +1,7 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../../../tsconfig.dist.json",
   "compilerOptions": {
-    "allowJs": false,
-    "checkJs": false,
-    "noEmit": true,
-    "rootDir": "../..",
-    "exactOptionalPropertyTypes": true,
-    "verbatimModuleSyntax": true,
-    "erasableSyntaxOnly": true
+    "rootDir": "../.."
   },
-  "files": [],
   "include": [".", "../../dist"]
 }

--- a/packages/core/tests/types/tsconfig.json
+++ b/packages/core/tests/types/tsconfig.json
@@ -1,11 +1,15 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "exactOptionalPropertyTypes": true,
+    "allowJs": false,
+    "checkJs": false,
     "noEmit": true,
     "rootDir": "../..",
     "strict": true,
-    "verbatimModuleSyntax": true
+    "exactOptionalPropertyTypes": true,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true
   },
+  "files": [],
   "include": [".", "../../dist"]
 }

--- a/packages/core/tests/types/tsconfig.json
+++ b/packages/core/tests/types/tsconfig.json
@@ -1,15 +1,7 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../../../tsconfig.dist.json",
   "compilerOptions": {
-    "allowJs": false,
-    "checkJs": false,
-    "noEmit": true,
-    "rootDir": "../..",
-    "strict": true,
-    "exactOptionalPropertyTypes": true,
-    "verbatimModuleSyntax": true,
-    "erasableSyntaxOnly": true
+    "rootDir": "../.."
   },
-  "files": [],
   "include": [".", "../../dist"]
 }

--- a/packages/object-schema/tests/types/tsconfig.json
+++ b/packages/object-schema/tests/types/tsconfig.json
@@ -1,15 +1,7 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../../../tsconfig.dist.json",
   "compilerOptions": {
-    "allowJs": false,
-    "checkJs": false,
-    "noEmit": true,
-    "rootDir": "../..",
-    "strict": true,
-    "exactOptionalPropertyTypes": true,
-    "verbatimModuleSyntax": true,
-    "erasableSyntaxOnly": true
+    "rootDir": "../.."
   },
-  "files": [],
   "include": [".", "../../dist"]
 }

--- a/packages/object-schema/tests/types/tsconfig.json
+++ b/packages/object-schema/tests/types/tsconfig.json
@@ -1,12 +1,15 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "allowJs": false,
+    "checkJs": false,
     "noEmit": true,
     "rootDir": "../..",
     "strict": true,
     "exactOptionalPropertyTypes": true,
-    "noImplicitAny": false,
-    "useUnknownInCatchVariables": false
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true
   },
+  "files": [],
   "include": [".", "../../dist"]
 }

--- a/packages/plugin-kit/tests/types/tsconfig.json
+++ b/packages/plugin-kit/tests/types/tsconfig.json
@@ -1,10 +1,14 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "allowJs": false,
+    "checkJs": false,
     "noEmit": true,
     "rootDir": "../..",
-    "strict": true,
-    "exactOptionalPropertyTypes": true
+    "exactOptionalPropertyTypes": true,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true
   },
+  "files": [],
   "include": [".", "../../dist"]
 }

--- a/packages/plugin-kit/tests/types/tsconfig.json
+++ b/packages/plugin-kit/tests/types/tsconfig.json
@@ -1,14 +1,7 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../../../tsconfig.dist.json",
   "compilerOptions": {
-    "allowJs": false,
-    "checkJs": false,
-    "noEmit": true,
-    "rootDir": "../..",
-    "exactOptionalPropertyTypes": true,
-    "verbatimModuleSyntax": true,
-    "erasableSyntaxOnly": true
+    "rootDir": "../.."
   },
-  "files": [],
   "include": [".", "../../dist"]
 }

--- a/templates/package/tests/types/tsconfig.json
+++ b/templates/package/tests/types/tsconfig.json
@@ -1,14 +1,7 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../../../tsconfig.dist.json",
   "compilerOptions": {
-    "allowJs": false,
-    "checkJs": false,
-    "noEmit": true,
-    "rootDir": "../..",
-    "exactOptionalPropertyTypes": true,
-    "verbatimModuleSyntax": true,
-    "erasableSyntaxOnly": true
+    "rootDir": "../.."
   },
-  "files": [],
   "include": [".", "../../dist"]
 }

--- a/templates/package/tests/types/tsconfig.json
+++ b/templates/package/tests/types/tsconfig.json
@@ -1,8 +1,14 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "allowJs": false,
+    "checkJs": false,
     "noEmit": true,
-    "rootDir": "../.."
+    "rootDir": "../..",
+    "exactOptionalPropertyTypes": true,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true
   },
+  "files": [],
   "include": [".", "../../dist"]
 }

--- a/tsconfig.dist-legacy.json
+++ b/tsconfig.dist-legacy.json
@@ -7,8 +7,8 @@
     "noEmit": true,
     "strict": true,
     "exactOptionalPropertyTypes": true,
-    "verbatimModuleSyntax": true,
-    "erasableSyntaxOnly": true
+    "verbatimModuleSyntax": true
+    // "erasableSyntaxOnly" is not supported in TypeScript < 5.8.
   },
   "include": ["packages/*/dist", "packages/*/tests/types"]
 }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [X] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

add tests in CI

#### What changes did you make? (Give an overview)

This PR adds type tests for TypeScript v.5.x besides existing tests targeting TypeScript v5.3 and v6.0.

It also enables the TypeScript compiler options `strict`, `exactOptionalPropertyTypes`, `verbatimModuleSyntax` and `erasableSyntaxOnly` for all type tests, and disables type checking for JavaScript files compiled or emitted by `tsc` during the build.

These changes align this repo with `eslint/json` and `eslint/markdown`.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

refs eslint/json#230

#### Is there anything you'd like reviewers to focus on?

**Question**: Shall we also add type tests for TypeScript 7? It's still in the beta prerelease, but there was already a regression reported in #425 for an issue that only occurs in TypeScript 7. @eslint/eslint-team
