### PR TITLE
test: run type tests with TypeScript 7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,9 @@ jobs:
             - name: Check dist types compile (TypeScript 5.x)
               run: npm run test:types:5.x
 
+            - name: Check dist types compile (TypeScript 7 preview)
+              run: npm run test:types:7.x
+
     are-the-types-wrong:
         name: Are the types wrong?
         runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test:types": "tsc && npm run test:types --workspaces --if-present",
     "test:types:5.3": "npx -p typescript@5.3 -y -- tsc -p tsconfig.dist-legacy.json",
     "test:types:5.x": "npx -p typescript@5.x -y -- tsc -p tsconfig.dist.json",
-    "test:types:all": "npm run test:types && npm run test:types:5.x && npm run test:types:5.3",
+    "test:types:7.x": "npx -p @typescript/native-preview@latest -y -- tsgo -p tsconfig.dist.json",
+    "test:types:all": "npm run test:types && npm run test:types:5.3 && npm run test:types:5.x && npm run test:types:7.x",
     "test:unit": "npm run test:unit --workspaces --if-present"
   },
   "workspaces": [


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [X] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

This PR ensures that type tests are run in TypeScript 7 preview besides TypeScript 5.3, 5.x and 6.x.

#### What changes did you make? (Give an overview)

* Updated "Test Types" CI job
* Added npm script `test:types:7.x` and extended `test:types:all`

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

fixes #443