### PR TITLE
ci: add Node.js 26 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         strategy:
             matrix:
                 os: [windows-latest, macOS-latest, ubuntu-latest]
-                node-version: [25.x, 24.x, 22.x, 20.x, "20.19.0"]
+                node-version: [26.x, 25.x, 24.x, 22.x, 20.x, "20.19.0"]
 
         steps:
             - uses: actions/checkout@v6


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

On May 5, 2026, Node.js 26 was released.

Ref: https://github.com/nodejs/node/releases/tag/v26.0.0

This PR is a straightforward CI matrix update to run tests on Node.js 26.

#### What changes did you make? (Give an overview)

This PR is a straightforward CI matrix update to run tests on Node.js 26.

#### Related Issues

N/A

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

N/A