### PR TITLE
chore: use includeIgnoreFile() internally

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,14 +1,23 @@
 import eslintConfigESLint from "eslint-config-eslint";
-import { defineConfig } from "@eslint/config-helpers";
+import { defineConfig, includeIgnoreFile } from "@eslint/config-helpers";
 import tseslint from "typescript-eslint";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
 
 const eslintPluginJSDoc = eslintConfigESLint.find(
 	config => config.plugins?.jsdoc,
 ).plugins.jsdoc;
 
+const filename = fileURLToPath(import.meta.url);
+const dirname = path.dirname(filename);
+
 export default defineConfig([
+	includeIgnoreFile(path.join(dirname, ".gitignore"), {
+		gitignoreResolution: true,
+	}),
+
 	{
-		ignores: ["**/tests/fixtures/", "**/dist/", "**/coverage/"],
+		ignores: ["**/tests/fixtures/"],
 	},
 
 	{


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

#### What changes did you make? (Give an overview)

Use `includeIgnoreFile()` internally (since https://github.com/eslint/eslint/pull/20735 was recently released).

Removed things from the explicit global ignores list that are already gitignored.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
