### PR TITLE
chore: pin fflate@0.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,9 @@
   "overrides": {
     "eslint": {
       "@eslint/core": "file:packages/core"
+    },
+    "@arethetypeswrong/core": {
+      "fflate": "0.8.2"
     }
   }
 }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

Similar to https://github.com/eslint/eslint/pull/20877.

Fixes CI failure when running `lint:types` scripts:

https://github.com/eslint/rewrite/actions/runs/25950047972/job/76286009745

```
Run npm run lint:types

> eslint-rewrite@1.0.0 lint:types
> npm run lint:types --workspaces --if-present


> @eslint/compat@2.1.0 lint:types
> attw --pack

error while checking file:
Cannot read properties of undefined (reading 'filename')
npm error Lifecycle script `lint:types` failed with error:
npm error code 3
npm error path /home/runner/work/rewrite/rewrite/packages/compat
npm error workspace @eslint/compat@2.1.0
npm error location /home/runner/work/rewrite/rewrite/packages/compat
npm error command failed
npm error command sh -c attw --pack

...
(same for all other packages)
```

#### What changes did you make? (Give an overview)

Per https://github.com/arethetypeswrong/arethetypeswrong.github.io/issues/258, the problem is caused by `@arethetypeswrong/core` relying on an internal behavior of `fflate`, which has changed in recently released v0.8.3.

As this might not be fixed soon, this PR adds `overrides` to pin `fflate` to v0.8.2 for `@arethetypeswrong/core`. 

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
