### PR TITLE
chore: update @arethetypeswrong/cli to 0.18.3

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,6 @@
 {
 	$schema: "https://docs.renovatebot.com/renovate-schema.json",
 	extends: ["github>eslint/workflows//.github/renovate/eslint-base.json5"],
-	ignoreDeps: ["fflate"],
 	packageRules: [
 		{
 			description: "Update `eslint` and `espree` in dependencies",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "node": "^22.13.0 || >=24"
   },
   "devDependencies": {
-    "@arethetypeswrong/cli": "^0.18.2",
+    "@arethetypeswrong/cli": "^0.18.3",
     "@eslint/config-helpers": "file:packages/config-helpers",
     "@types/mocha": "^10.0.7",
     "@types/node": "^24.9.1",
@@ -58,9 +58,6 @@
   "overrides": {
     "eslint": {
       "@eslint/core": "file:packages/core"
-    },
-    "@arethetypeswrong/core": {
-      "fflate": "0.8.2"
     }
   }
 }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

This PR updates `@arethetypeswrong/cli` to version `0.18.3`. This update resolves a previous dependency issue, allowing us to clean up the temporary `fflate` workaround.

#### What changes did you make? (Give an overview)

- Updated `@arethetypeswrong/cli` from `^0.18.2` to `^0.18.3`.
- Removed the `fflate` version override and removed the now-empty `ignoreDeps` rule from Renovate's configuration.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
