### PR TITLE
chore: add prettier update commit to `.git-blame-ignore-revs`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# #476 chore: update prettier to v3.9.0
+18abab1ad421688511bfa96feefa69bc0c98ae90


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

This PR simply adds the `prettier` update commit from https://github.com/eslint/rewrite/pull/476 to `.git-blame-ignore-revs` so formatting-only diffs won’t show up in the `git blame` view.

I've followed the same pattern from https://github.com/eslint/eslint/blob/main/.git-blame-ignore-revs.

#### What changes did you make? (Give an overview)

Added `.git-blame-ignore-revs`.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
