### PR TITLE
feat: alias `Config` to `ConfigObject`

### DIFF
--- a/packages/config-helpers/src/define-config.js
+++ b/packages/config-helpers/src/define-config.js
@@ -411,10 +411,10 @@ function processExtends(config, configNames) {
 	}
 
 	const {
-		/** @type {Config[]} */
+		/** @type {ConfigObject[]} */
 		extends: extendsList,
 
-		/** @type {Config} */
+		/** @type {ConfigObject} */
 		...configObject
 	} = config;
 

--- a/packages/config-helpers/src/define-config.js
+++ b/packages/config-helpers/src/define-config.js
@@ -7,15 +7,16 @@
 // Type Definitions
 //-----------------------------------------------------------------------------
 
-/** @typedef {import("@eslint/core").ConfigObject} Config */
+/** @typedef {import("@eslint/core").ConfigObject} ConfigObject */
 /** @typedef {import("@eslint/core").LegacyConfigObject} LegacyConfig */
 /** @typedef {import("@eslint/core").Plugin} Plugin */
 /** @typedef {import("@eslint/core").RuleConfig} RuleConfig */
+/** @typedef {import("./types.ts").Config} Config */
 /** @typedef {import("./types.ts").ExtendsElement} ExtendsElement */
 /** @typedef {import("./types.ts").ExtensionConfigObject} ExtensionConfigObject */
 /** @typedef {import("./types.ts").SimpleExtendsElement} SimpleExtendsElement */
 /** @typedef {import("./types.ts").ConfigWithExtends} ConfigWithExtends */
-/** @typedef {import("./types.ts").InfiniteArray<Config>} InfiniteConfigArray */
+/** @typedef {import("./types.ts").InfiniteArray<ConfigObject>} InfiniteConfigArray */
 /** @typedef {import("./types.ts").ConfigWithExtendsArray} ConfigWithExtendsArray */
 
 //-----------------------------------------------------------------------------
@@ -39,7 +40,7 @@ const allowedGlobalIgnoreKeys = new Set(["basePath", "ignores", "name"]);
 
 /**
  * Gets the name of a config object.
- * @param {Config} config The config object.
+ * @param {ConfigObject} config The config object.
  * @param {string} indexPath The index path of the config object.
  * @return {string} The name of the config object.
  */
@@ -71,7 +72,7 @@ function getExtensionName(extension, indexPath) {
 
 /**
  * Determines if a config object is a legacy config.
- * @param {Config|LegacyConfig} config The config object to check.
+ * @param {ConfigObject|LegacyConfig} config The config object to check.
  * @return {config is LegacyConfig} `true` if the config object is a legacy config.
  */
 function isLegacyConfig(config) {
@@ -91,7 +92,7 @@ function isLegacyConfig(config) {
 
 /**
  * Determines if a config object is a global ignores config.
- * @param {Config} config The config object to check.
+ * @param {ConfigObject} config The config object to check.
  * @return {boolean} `true` if the config object is a global ignores config.
  */
 function isGlobalIgnores(config) {
@@ -138,8 +139,8 @@ function getPluginMember(id) {
  * Normalizes the plugin config by replacing the namespace with the plugin namespace.
  * @param {string} userNamespace The namespace of the plugin.
  * @param {Plugin} plugin The plugin config object.
- * @param {Config} config The config object to normalize.
- * @return {Config} The normalized config object.
+ * @param {ConfigObject} config The config object to normalize.
+ * @return {ConfigObject} The normalized config object.
  */
 function normalizePluginConfig(userNamespace, plugin, config) {
 	const pluginNamespace = plugin.meta?.namespace;
@@ -207,7 +208,7 @@ function normalizePluginConfig(userNamespace, plugin, config) {
  * Deeply normalizes a plugin config, traversing recursively into an arrays.
  * @param {string} userPluginNamespace The namespace of the plugin.
  * @param {Plugin} plugin The plugin object.
- * @param {Config|LegacyConfig|(Config|LegacyConfig)[]} pluginConfig The plugin config to normalize.
+ * @param {ConfigObject|LegacyConfig|(ConfigObject|LegacyConfig)[]} pluginConfig The plugin config to normalize.
  * @param {string} pluginConfigName The name of the plugin config.
  * @return {InfiniteConfigArray} The normalized plugin config.
  * @throws {TypeError} If the plugin config is a legacy config.
@@ -242,7 +243,7 @@ function deepNormalizePluginConfig(
 
 /**
  * Finds a plugin config by name in the given config.
- * @param {Config} config The config object.
+ * @param {ConfigObject} config The config object.
  * @param {string} pluginConfigName The name of the plugin config.
  * @return {InfiniteConfigArray} The plugin config.
  * @throws {TypeError} If the plugin config is not found or is a legacy config.
@@ -362,11 +363,11 @@ function extendConfigFiles(baseFiles = [], extensionFiles = []) {
 
 /**
  * Extends a config object with another config object.
- * @param {Config} baseConfig The base config object.
+ * @param {ConfigObject} baseConfig The base config object.
  * @param {string} baseConfigName The name of the base config object.
- * @param {Config} extension The extension config object.
+ * @param {ConfigObject} extension The extension config object.
  * @param {string} extensionName The index of the extension config object.
- * @return {Config} The extended config object.
+ * @return {ConfigObject} The extended config object.
  */
 function extendConfig(baseConfig, baseConfigName, extension, extensionName) {
 	const result = { ...extension };
@@ -396,8 +397,8 @@ function extendConfig(baseConfig, baseConfigName, extension, extensionName) {
 /**
  * Processes a list of extends elements.
  * @param {ConfigWithExtends} config The config object.
- * @param {WeakMap<Config, string>} configNames The map of config objects to their names.
- * @return {Config[]} The flattened list of config objects.
+ * @param {WeakMap<ConfigObject, string>} configNames The map of config objects to their names.
+ * @return {ConfigObject[]} The flattened list of config objects.
  * @throws {TypeError} If the `extends` property is not an array or if nested `extends` is found.
  */
 function processExtends(config, configNames) {
@@ -439,7 +440,7 @@ function processExtends(config, configNames) {
 			return pluginConfig;
 		}
 
-		return /** @type {Config} */ (extendsElement);
+		return /** @type {ConfigObject} */ (extendsElement);
 	});
 
 	const result = [];
@@ -447,7 +448,7 @@ function processExtends(config, configNames) {
 	for (const { indexPath, value: extendsElement } of flatTraverse(
 		objectExtends,
 	)) {
-		const extension = /** @type {Config} */ (extendsElement);
+		const extension = /** @type {ConfigObject} */ (extendsElement);
 
 		if ("basePath" in extension) {
 			throw new TypeError("'basePath' in `extends` is not allowed.");
@@ -492,8 +493,8 @@ function processExtends(config, configNames) {
 /**
  * Processes a list of config objects and arrays.
  * @param {ConfigWithExtends[]} configList The list of config objects and arrays.
- * @param {WeakMap<Config, string>} configNames The map of config objects to their names.
- * @return {Config[]} The flattened list of config objects.
+ * @param {WeakMap<ConfigObject, string>} configNames The map of config objects to their names.
+ * @return {ConfigObject[]} The flattened list of config objects.
  */
 function processConfigList(configList, configNames) {
 	return configList.flatMap(config => processExtends(config, configNames));
@@ -506,7 +507,7 @@ function processConfigList(configList, configNames) {
 /**
  * Helper function to define a config array.
  * @param {ConfigWithExtendsArray} args The arguments to the function.
- * @returns {Config[]} The config array.
+ * @returns {ConfigObject[]} The config array.
  * @throws {TypeError} If no arguments are provided or if an argument is not an object.
  */
 export function defineConfig(...args) {

--- a/packages/config-helpers/src/global-ignores.js
+++ b/packages/config-helpers/src/global-ignores.js
@@ -7,7 +7,7 @@
 // Type Definitions
 //-----------------------------------------------------------------------------
 
-/** @typedef {import("@eslint/core").ConfigObject} Config */
+/** @typedef {import("@eslint/core").ConfigObject} ConfigObject */
 
 //-----------------------------------------------------------------------------
 // Helpers
@@ -23,7 +23,7 @@ let globalIgnoreCount = 0;
  * Creates a global ignores config with the given patterns.
  * @param {string[]} ignorePatterns The ignore patterns.
  * @param {string} [name] The name of the global ignores config.
- * @returns {Config} The global ignores config.
+ * @returns {ConfigObject} The global ignores config.
  * @throws {TypeError} If ignorePatterns is not an array or if it is empty.
  */
 export function globalIgnores(ignorePatterns, name) {

--- a/packages/config-helpers/src/ignore-file.js
+++ b/packages/config-helpers/src/ignore-file.js
@@ -17,7 +17,7 @@ import path from "node:path";
 // Types
 //-----------------------------------------------------------------------------
 
-/** @typedef {import("@eslint/core").ConfigObject} Config */
+/** @typedef {import("@eslint/core").ConfigObject} ConfigObject */
 
 /**
  * @typedef {object} IncludeIgnoreFileOptionsObject
@@ -141,7 +141,7 @@ function parseOptions(options) {
  *
  * @param {string[]} ignoreFilePathArg The paths of ignore files to include.
  * @param {IncludeIgnoreFileOptions} [options]
- * @returns {Config[]}
+ * @returns {ConfigObject[]}
  */
 
 /**
@@ -151,7 +151,7 @@ function parseOptions(options) {
  *
  * @param {string} ignoreFilePathArg The path of the ignore file to include.
  * @param {IncludeIgnoreFileOptions} [options]
- * @returns {Config}
+ * @returns {ConfigObject}
  */
 
 /**
@@ -161,7 +161,7 @@ function parseOptions(options) {
  *
  * @param {string[] | string} ignoreFilePathArg The path(s) of the ignore file(s) to include.
  * @param {IncludeIgnoreFileOptions} [options]
- * @returns {Config[] | Config}
+ * @returns {ConfigObject[] | ConfigObject}
  */
 
 /**
@@ -169,7 +169,7 @@ function parseOptions(options) {
  *
  * @param {string[] | string} ignoreFilePathArg The path(s) of the ignore file(s) to include.
  * @param {IncludeIgnoreFileOptions} [options]
- * @returns {Config[] | Config}
+ * @returns {ConfigObject[] | ConfigObject}
  */
 export function includeIgnoreFile(ignoreFilePathArg, options) {
 	const returnSingleObject = !Array.isArray(ignoreFilePathArg);

--- a/packages/config-helpers/src/types.ts
+++ b/packages/config-helpers/src/types.ts
@@ -4,6 +4,9 @@
 
 import type { ConfigObject } from "@eslint/core";
 
+/** @deprecated Use `ConfigObject` instead. */
+export type Config = ConfigObject;
+
 /**
  * Infinite array type.
  */

--- a/packages/config-helpers/tests/types/types.test.ts
+++ b/packages/config-helpers/tests/types/types.test.ts
@@ -10,6 +10,7 @@
 import {
 	defineConfig,
 	type Config,
+	type ConfigObject,
 	type ConfigWithExtends,
 	type ExtensionConfigObject,
 	globalIgnores,
@@ -74,7 +75,7 @@ defineConfig([], {});
 defineConfig([{}]);
 defineConfig([globalIgnores(["node_modules"])], []);
 
-declare const recommendedConfigs: Config[];
+declare const recommendedConfigs: ConfigObject[];
 
 defineConfig(...recommendedConfigs, {
 	linterOptions: { noInlineConfig: true },


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

This PR exports `ConfigObject` from `@eslint/config-helpers` and aliases the existing `Config` type to it.

#### What changes did you make? (Give an overview)

- Updated `types.ts` to export `Config` as a deprecated alias of `ConfigObject`.
- Replaced the `Config` JSDoc `@typedef` with `ConfigObject` in `define-config.js`, `global-ignores.js`, and `ignore-file.js`.
- Updated type tests to verify that both `ConfigObject` and `Config` are correctly exported.

#### Related Issues

Fixes #478

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
