### PR TITLE
docs: correct field and method names in plugin-kit example

### DIFF
--- a/packages/plugin-kit/README.md
+++ b/packages/plugin-kit/README.md
@@ -232,7 +232,7 @@ export class MySourceCode extends TextSourceCodeBase {
 
 		for (const { node, parent, phase } of iterator(this.ast)) {
 			//save the parent information
-			this.#parent.set(node, parent);
+			this.#parents.set(node, parent);
 
 			steps.push(
 				new VisitNodeStep({
@@ -248,7 +248,7 @@ export class MySourceCode extends TextSourceCodeBase {
 }
 ```
 
-In general, it's safe to collect the parent information during the `traverse()` method as `getParent()` and `getAncestor()` will only be called from rules once the AST has been traversed at least once.
+In general, it's safe to collect the parent information during the `traverse()` method as `getParent()` and `getAncestors()` will only be called from rules once the AST has been traversed at least once.
 
 ## License
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

- Documentation update

<img width="523" height="332" alt="image" src="https://github.com/user-attachments/assets/dae32d23-17a6-4531-90b3-f773cf3e1d8d" />

<img width="683" height="72" alt="image" src="https://github.com/user-attachments/assets/aba5fc4c-78d1-4248-8c8c-69be5836f5c7" />

Hello! This is a small fix for the `MySourceCode` example in the `@eslint/plugin-kit` README.

Inside `traverse()`, the example writes to `this.#parent`, but the class only declares `#parents` (and `getParent()` reads from `this.#parents`). Since `#parent` is never declared, loading the example throws `SyntaxError: Private field '#parent' must be declared in an enclosing class`, so it doesn't run as written. Changing it to `#parents` lines up with the declared field and the `getParent()` reader.

While there, I also noticed the sentence below the example mentions `getAncestor()`, but the actual method is `getAncestors()` (it's listed correctly a bit higher up in the same README, and defined in `source-code.js`).

#### What changes did you make? (Give an overview)

- `this.#parent.set(...)` -> `this.#parents.set(...)` (match the declared field)
- `getAncestor()` -> `getAncestors()` in the surrounding prose

Two lines in `packages/plugin-kit/README.md`.

#### Related Issues

None

#### Is there anything you'd like reviewers to focus on?

Nothing in particular. It's a docs-only two-line change.
