### PR TITLE
build: add `@eslint/core` devDependency to `mcp`

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@cfworker/json-schema": "^4.1.1",
+    "@eslint/core": "^1.2.1",
     "@eslint/plugin-kit": "^0.7.2",
     "@types/express": "^5.0.6",
     "@types/node": "^24.7.2"


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

Fix the build by fixing an error in `ci-bun`, e.g. https://github.com/eslint/rewrite/actions/runs/32727569725/job/97432217393

#### What changes did you make? (Give an overview)

Added `@eslint/core` as a devDependency to the `mcp` package. Bun is failing with an error message indicating that `@eslint/core` cannot be found.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
