### PR TITLE
ci: use hoisted linker for bun installs

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[install]
+linker = "hoisted"


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

This PR fixes the `ci-bun` job, which has been failing on every branch since Bun 1.4.0 was released.

Bun 1.4.0 made the isolated linker the default for monorepos whose lockfile has `configVersion: 1`. We don't commit `bun.lock`, so CI always generates a fresh one and always gets isolated linking.

#### What changes did you make? (Give an overview)

Added a root `bunfig.toml` pinning Bun to the hoisted linker.

#### Related Issues

https://github.com/eslint/rewrite/actions/runs/32868554819/job/97869747114

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
