### PR TITLE
chore: stop posting releases to Twitter

### DIFF
--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -79,12 +79,8 @@ jobs:
               working-directory: packages/${{ inputs.package }}
 
             - name: Post Release Announcement
-              run: npx @humanwhocodes/crosspost -t -b -m "eslint/${{ inputs.package }} v${{ steps.get-version.outputs.version }} has been released!\n\nhttps://github.com/eslint/rewrite/releases/tag/${{ steps.get-latest-release.outputs.latest_tag }}"
+              run: npx @humanwhocodes/crosspost -b -m "eslint/${{ inputs.package }} v${{ steps.get-version.outputs.version }} has been released!\n\nhttps://github.com/eslint/rewrite/releases/tag/${{ steps.get-latest-release.outputs.latest_tag }}"
               env:
-                  TWITTER_API_CONSUMER_KEY: ${{ secrets.TWITTER_CONSUMER_KEY }}
-                  TWITTER_API_CONSUMER_SECRET: ${{ secrets.TWITTER_CONSUMER_SECRET }}
-                  TWITTER_ACCESS_TOKEN_KEY: ${{ secrets.TWITTER_ACCESS_TOKEN_KEY }}
-                  TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
                   MASTODON_ACCESS_TOKEN: ${{ secrets.MASTODON_ACCESS_TOKEN }}
                   MASTODON_HOST: ${{ secrets.MASTODON_HOST }}
                   BLUESKY_IDENTIFIER: ${{ vars.BLUESKY_IDENTIFIER }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -58,10 +58,6 @@ jobs:
                   STEPS_RELEASE_OUTPUTS: ${{ toJson(steps.release.outputs) }}
                   GITHUB_REF_NAME: ${{ github.ref_name }}
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  TWITTER_API_CONSUMER_KEY: ${{ secrets.TWITTER_CONSUMER_KEY }}
-                  TWITTER_API_CONSUMER_SECRET: ${{ secrets.TWITTER_CONSUMER_SECRET }}
-                  TWITTER_ACCESS_TOKEN_KEY: ${{ secrets.TWITTER_ACCESS_TOKEN_KEY }}
-                  TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
                   MASTODON_ACCESS_TOKEN: ${{ secrets.MASTODON_ACCESS_TOKEN }}
                   MASTODON_HOST: ${{ secrets.MASTODON_HOST }}
                   BLUESKY_IDENTIFIER: ${{ vars.BLUESKY_IDENTIFIER }}

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -220,7 +220,7 @@ function postResultToSocialMedia(npmPublishResults) {
 		console.log(message);
 
 		exec(
-			`npx @humanwhocodes/crosspost -t -b -m ${JSON.stringify(message)}`,
+			`npx @humanwhocodes/crosspost -b -m ${JSON.stringify(message)}`,
 			{
 				stdio: "inherit",
 				env: process.env,

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -219,13 +219,10 @@ function postResultToSocialMedia(npmPublishResults) {
 
 		console.log(message);
 
-		exec(
-			`npx @humanwhocodes/crosspost -b -m ${JSON.stringify(message)}`,
-			{
-				stdio: "inherit",
-				env: process.env,
-			},
-		);
+		exec(`npx @humanwhocodes/crosspost -b -m ${JSON.stringify(message)}`, {
+			stdio: "inherit",
+			env: process.env,
+		});
 	}
 
 	console.log("Posted to social media.");


### PR DESCRIPTION
## Summary

This stops posting release announcements to Twitter. Announcements still go to Bluesky and Mastodon.

## Why

Posting to Twitter now costs money. Most of the packages in this repo are dependencies of other packages, so most people never use them directly. Announcing their releases on Twitter isn't worth that cost.

## Changes

- `scripts/publish.js`: removed the `-t` (Twitter) flag from the `crosspost` command, leaving `-b` (Bluesky) and `-m` (Mastodon).
- `.github/workflows/release-please.yml`: removed the four `TWITTER_*` secrets from the publish step.
- `.github/workflows/manual-publish.yml`: made the same two changes to the announcement step.

## Follow-up

After this merges, the `TWITTER_CONSUMER_KEY`, `TWITTER_CONSUMER_SECRET`, `TWITTER_ACCESS_TOKEN_KEY`, and `TWITTER_ACCESS_TOKEN_SECRET` repository secrets can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Yb8CcLGRFou12E8cgqxMb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Changes**
  - Release announcements are no longer posted to Twitter.
  - Automated release announcements continue to be shared through Bluesky and Mastodon.
  - Twitter credentials are no longer required for release publishing workflows.
  - This update streamlines the release announcement process while preserving existing social media distribution through the remaining supported channels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->